### PR TITLE
Fix Reset Control Graph leaving Dui2 in a stuck state (#81)

### DIFF
--- a/src/dui2/client/q_object.py
+++ b/src/dui2/client/q_object.py
@@ -1627,13 +1627,15 @@ class MainObject(QObject):
             logging.info("Cancel clicked to reset")
 
     def reset_ended(self):
-        self.request_display()
         self.curr_nod_num = 0
+        self.new_node = None
+        self.curr_widg_key = "root"
+        self.request_display()
         logging.info(
             " self.curr_nod_num =" + str( self.curr_nod_num) +
             "self.server_nod_lst = " + str( self.server_nod_lst)
         )
-        self.check_nxt_btn()
+        self.import_init()
 
     def post_ended(self):
         self.request_display()


### PR DESCRIPTION
Edit: Note: Claude Generated this PR
## Summary

Fixes #81. After confirming the **Reset Control Graph** menu option, Dui2 was left with no way to run `dials.import` (or anything else) — the user had to restart the app.

The server side was working correctly: `reset_graph` cleared everything back to the root node. The bug was entirely on the client.

## Root cause

`MainObject.reset_ended()` did this:

```python
def reset_ended(self):
    self.request_display()
    self.curr_nod_num = 0
    ...
    self.check_nxt_btn()
```

Two problems:

1. **Stale client state during redraw.** `request_display()` calls `display()`, which uses `self.curr_nod_num`, `self.new_node`, and `self.curr_widg_key`. After a reset the server only contains the root node, but those client fields still pointed at the pre-reset graph — so the tree was being redrawn against references that no longer existed.
2. **No affordance to run `dials.import`.** `check_nxt_btn()` → `add_next2do_button()` → `update_nxt_butt()` only adds a next-step button when the current node is `Succeeded` (root is) — then instantiates `FindNextCmd(...)`, which immediately does `parent_num = parent_nod_num_lst[0]`. For the root node `parent_node_lst == []`, so this raises `IndexError`. The exception is caught silently in `update_nxt_butt`, and no button gets added. The result is a "stuck" empty UI, exactly as in the screenshots on the issue.

The expected behaviour from the issue is "go back to a clean state, as if the user just launched Dui2 from an empty directory". The launch flow already handles this correctly via `import_init()`: when `len(server_nod_lst) == 1`, it calls `nxt_key_clicked("import")` to bring up the import widget.

## Fix

Make `reset_ended()` mirror the startup flow:

- Reset `curr_nod_num`, `new_node`, and `curr_widg_key` **before** calling `request_display()`, so the redraw is consistent with the freshly reset server.
- Call `import_init()` at the end. With one node on the server, it opens the import widget the same way it does on launch.

This builds on the WIP commit 53ca51e ("starting to expose a bug related to the way << reset graph >> happens"), which split the reset handler off from `post_ended` and added the `curr_nod_num = 0` assignment.

## Test plan

- [ ] Launch Dui2 in an empty directory → confirm the import widget appears (regression check on startup path).
- [ ] Run `dials.import`, then `File → Reset Control Graph → Yes` → confirm the graph clears and the import widget reappears, identical to a fresh launch.
- [ ] After reset, run `dials.import` on a fresh dataset → confirm the new node is created and the rest of the pipeline (find_spots, index, …) still works.
- [ ] Run several pipeline steps, then reset → confirm everything clears and import is available again.
- [ ] Cancel the reset confirmation dialog → confirm nothing changes (no regression on the cancel path).