### PR TITLE
Cross-platform file browser fixes and code cleanup

### DIFF
--- a/src/dui2/all_local_all_ram.py
+++ b/src/dui2/all_local_all_ram.py
@@ -103,7 +103,7 @@ def main():
             recovery_data = None, dat_ini = server_data_init
         )
 
-    print("tree_ini_path(all_loca_all_ram) =", tree_ini_path)
+    logging.info("tree_ini_path(all_loca_all_ram) =" + str(tree_ini_path))
 
     cmd_runner.set_dir_path(tree_ini_path)
 

--- a/src/dui2/all_local_all_ram.py
+++ b/src/dui2/all_local_all_ram.py
@@ -33,11 +33,9 @@ def main():
     else:
         print("neither Linux or Windows")
 
-    #    ("limit_path", "/home/ufn91840/V_Box_compartido"),
-
     par_def = (
         ("chdir", None),
-        ("limit_path", "/"),
+        ("limit_path", None),
         ("import_init", None),
         ("all_local", "true"),
         ("windows_exe", win_str),
@@ -82,12 +80,16 @@ def main():
     os.chdir(nodes_dir)
     tree_ini_path = init_param["limit_path"]
     if tree_ini_path == None:
+        tree_ini_path = ""
+        '''
+        #TODO: consider the approach of the next 3 instructions instead
         logging.info(
             " using the dir from where the commad 'dui2_server_side' was invoqued"
         )
-        tree_ini_path = os.getcwd()
+        from pathlib import Path
+        tree_ini_path = str(Path.cwd().parent)
+        '''
 
-    #tree_dic_lst = iter_dict(tree_ini_path, 0)
     try:
         with open("run_data") as json_file:
             runner_data = json.load(json_file)
@@ -100,6 +102,8 @@ def main():
         cmd_runner = multi_node.Runner(
             recovery_data = None, dat_ini = server_data_init
         )
+
+    print("tree_ini_path(all_loca_all_ram) =", tree_ini_path)
 
     cmd_runner.set_dir_path(tree_ini_path)
 

--- a/src/dui2/client/file_nav_utils.py
+++ b/src/dui2/client/file_nav_utils.py
@@ -168,7 +168,7 @@ class PathButtons(QWidget):
 
         self.lst_butt.append(new_lab)
         self.main_h_lay.addWidget(new_lab)
-
+        print("parent_dir_path :::", parent_dir_path, ":::")
         return parent_dir_path
 
     def dir_clicked(self):
@@ -208,6 +208,9 @@ class PathBar(QWidget):
 
     def up_dir(self, next_path):
         if self.par_dir is not None:
+
+            print("next_path :::", next_path, ":::")
+
             self.clicked_up_dir.emit(next_path)
 
 
@@ -318,7 +321,8 @@ class FileBrowser(QDialog):
         self.lst_vw =  MyDirView_list()
 
         self.root_limit_path = limit_path
-        #self.root_limit_path = ""
+        #self.root_limit_path = "/"
+        print("self.root_limit_path :::", self.root_limit_path, ":::")
 
         self.build_content(path_ini)
 
@@ -351,8 +355,9 @@ class FileBrowser(QDialog):
         self.show()
 
     def build_content(self, path_in):
-        self.curr_path = path_in
+        print("path_in :::", path_in, ":::")
 
+        self.curr_path = path_in
         system = platform.system()
         if system == "Windows":
             print("Nothing to do here ... for now")
@@ -369,9 +374,14 @@ class FileBrowser(QDialog):
 
         print("self.root_limit_path:::", self.root_limit_path, ":::")
         parents_list = [self.root_limit_path[:-1]]
-        print("parents_list:::", parents_list, ":::")
-        print("self.curr_path :::", self.curr_path, ":::")
-        rest_of_path = self.curr_path[len(self.root_limit_path):]
+        print("self.curr_path :::", self.curr_path, ":::\n")
+
+        len_lim = len(self.root_limit_path)
+        if len_lim > 1:
+            rest_of_path = self.curr_path[len_lim:]
+
+        else:
+            rest_of_path = self.curr_path
 
         print("rest_of_path", rest_of_path, ":::")
 

--- a/src/dui2/client/file_nav_utils.py
+++ b/src/dui2/client/file_nav_utils.py
@@ -129,7 +129,13 @@ class PathButtons(QWidget):
             self.main_h_lay.removeWidget(single_widget)
 
         self.lst_butt = []
-        path_str = ""
+
+        if platform.system() == "Windows":
+            path_str = ""
+
+        else:
+            path_str = "/"
+
         parent_dir_path = None
         for dir_name in new_list[:-1]:
             new_butt = QPushButton(dir_name)
@@ -160,6 +166,7 @@ class PathButtons(QWidget):
 
     def dir_clicked(self):
         next_path = str(self.sender().own_path)
+        print("next_path =", next_path)
         self.up_dir_clickled.emit(next_path)
 
 
@@ -393,10 +400,8 @@ class FileBrowser(QDialog):
             self.OpenButton.setEnabled(True)
 
     def new_path_text(self, new_path):
-
-
-
         self.typed_path = str(new_path)
+        print("\n FileBrowser.typed_path =", self.typed_path, "\n")
 
     def done_requesting(self, lst_dir):
         self.lst_vw.enter_list(lst_in = lst_dir)

--- a/src/dui2/client/file_nav_utils.py
+++ b/src/dui2/client/file_nav_utils.py
@@ -234,6 +234,9 @@ class ReqDirList(QThread):
             except IndexError:
                 curr_path = ""
 
+            if curr_path == "\\":
+                curr_path = ""
+
         else:
             # this is for unix style OS
             try:

--- a/src/dui2/client/file_nav_utils.py
+++ b/src/dui2/client/file_nav_utils.py
@@ -318,6 +318,8 @@ class FileBrowser(QDialog):
         self.lst_vw =  MyDirView_list()
 
         self.root_limit_path = limit_path
+        #self.root_limit_path = ""
+
         self.build_content(path_ini)
 
         self.lst_vw.file_clicked.connect(self.fill_clik)
@@ -350,16 +352,36 @@ class FileBrowser(QDialog):
 
     def build_content(self, path_in):
         self.curr_path = path_in
+
+        system = platform.system()
+        if system == "Windows":
+            print("Nothing to do here ... for now")
+
+        else:
+            if not self.curr_path.startswith("/"):
+                print("self.curr_path = ", self.curr_path)
+                self.curr_path = "/" + self.curr_path
+                print("self.curr_path = ", self.curr_path)
+
         self.refresh_content()
 
     def build_paren_list(self):
+
+        print("self.root_limit_path:::", self.root_limit_path, ":::")
         parents_list = [self.root_limit_path[:-1]]
+        print("parents_list:::", parents_list, ":::")
+        print("self.curr_path :::", self.curr_path, ":::")
         rest_of_path = self.curr_path[len(self.root_limit_path):]
+
+        print("rest_of_path", rest_of_path, ":::")
+
         try:
             if rest_of_path[-1] == "/" or rest_of_path[-1] == "\\":
+                print("cutting ", os.sep, "from:", rest_of_path)
                 rest_of_path = rest_of_path[:-1]
 
         except IndexError:
+            print("here IndexError")
             rest_of_path = ""
 
         system = platform.system()
@@ -373,6 +395,7 @@ class FileBrowser(QDialog):
             parents_list.append(single_dir)
 
         if parents_list[0:2] == ["", ""]:
+            print("removing \"\" from parents_list")
             parents_list = parents_list[1:]
 
         self.path_bar.update_list(parents_list, self.root_limit_path)

--- a/src/dui2/client/file_nav_utils.py
+++ b/src/dui2/client/file_nav_utils.py
@@ -123,18 +123,29 @@ class PathButtons(QWidget):
         self._curr_dir_font.setBold(True)
         self._curr_dir_font.setUnderline(True)
 
-    def update_list(self, new_list):
+    def update_list(self, new_list, root_limit_path):
         for single_widget in self.lst_butt:
             single_widget.deleteLater()
             self.main_h_lay.removeWidget(single_widget)
 
         self.lst_butt = []
 
+        # This << if >> block is a bit redundant to make clear
+        # that we need to handle the beginning of the path
+        # differently on windows that on Unix
+
         if platform.system() == "Windows":
             path_str = ""
 
         else:
-            path_str = "/"
+            if root_limit_path == "":
+                path_str = "/"
+
+            else:
+                path_str = ""
+
+
+        print("\n root_limit_path =", root_limit_path, "\n")
 
         parent_dir_path = None
 
@@ -199,8 +210,8 @@ class PathBar(QWidget):
     def scroll_2_right(self, minimum, maximum):
         self.hscrollbar.setValue(maximum)
 
-    def update_list(self, new_list):
-        self.par_dir = self.path_buttons.update_list(new_list)
+    def update_list(self, new_list, root_limit_path):
+        self.par_dir = self.path_buttons.update_list(new_list, root_limit_path)
 
     def up_dir(self, next_path):
         if self.par_dir is not None:
@@ -371,7 +382,7 @@ class FileBrowser(QDialog):
         if parents_list[0:2] == ["", ""]:
             parents_list = parents_list[1:]
 
-        self.path_bar.update_list(parents_list)
+        self.path_bar.update_list(parents_list, self.root_limit_path)
 
     def refresh_content(self):
         try:

--- a/src/dui2/client/file_nav_utils.py
+++ b/src/dui2/client/file_nav_utils.py
@@ -168,7 +168,7 @@ class PathButtons(QWidget):
 
         self.lst_butt.append(new_lab)
         self.main_h_lay.addWidget(new_lab)
-        print("parent_dir_path :::", parent_dir_path, ":::")
+        logging.debug("parent_dir_path :::" + str(parent_dir_path) + ":::")
         return parent_dir_path
 
     def dir_clicked(self):
@@ -209,7 +209,7 @@ class PathBar(QWidget):
     def up_dir(self, next_path):
         if self.par_dir is not None:
 
-            print("next_path :::", next_path, ":::")
+            logging.debug("next_path :::" + str(next_path) + ":::")
 
             self.clicked_up_dir.emit(next_path)
 
@@ -322,7 +322,7 @@ class FileBrowser(QDialog):
 
         self.root_limit_path = limit_path
         #self.root_limit_path = "/"
-        print("self.root_limit_path :::", self.root_limit_path, ":::")
+        logging.debug("self.root_limit_path :::" + str(self.root_limit_path) + ":::")
 
         self.build_content(path_ini)
 
@@ -355,26 +355,26 @@ class FileBrowser(QDialog):
         self.show()
 
     def build_content(self, path_in):
-        print("path_in :::", path_in, ":::")
+        logging.debug("path_in :::" + str(path_in) + ":::")
 
         self.curr_path = path_in
         system = platform.system()
         if system == "Windows":
-            print("Nothing to do here ... for now")
+            logging.debug("Nothing to do here ... for now")
 
         else:
             if not self.curr_path.startswith("/"):
-                print("self.curr_path = ", self.curr_path)
+                logging.debug("self.curr_path = " + str(self.curr_path))
                 self.curr_path = "/" + self.curr_path
-                print("self.curr_path = ", self.curr_path)
+                logging.debug("self.curr_path = " + str(self.curr_path))
 
         self.refresh_content()
 
     def build_paren_list(self):
 
-        print("self.root_limit_path:::", self.root_limit_path, ":::")
+        logging.debug("self.root_limit_path:::" + str(self.root_limit_path) + ":::")
         parents_list = [self.root_limit_path[:-1]]
-        print("self.curr_path :::", self.curr_path, ":::\n")
+        logging.debug("self.curr_path :::" + str(self.curr_path) + ":::")
 
         len_lim = len(self.root_limit_path)
         if len_lim > 1:
@@ -383,15 +383,15 @@ class FileBrowser(QDialog):
         else:
             rest_of_path = self.curr_path
 
-        print("rest_of_path", rest_of_path, ":::")
+        logging.debug("rest_of_path" + str(rest_of_path) + ":::")
 
         try:
             if rest_of_path[-1] == "/" or rest_of_path[-1] == "\\":
-                print("cutting ", os.sep, "from:", rest_of_path)
+                logging.debug("cutting " + os.sep + "from:" + str(rest_of_path))
                 rest_of_path = rest_of_path[:-1]
 
         except IndexError:
-            print("here IndexError")
+            logging.debug("here IndexError")
             rest_of_path = ""
 
         system = platform.system()
@@ -405,7 +405,7 @@ class FileBrowser(QDialog):
             parents_list.append(single_dir)
 
         if parents_list[0:2] == ["", ""]:
-            print("removing \"\" from parents_list")
+            logging.debug("removing \"\" from parents_list")
             parents_list = parents_list[1:]
 
         self.path_bar.update_list(parents_list, self.root_limit_path)

--- a/src/dui2/client/file_nav_utils.py
+++ b/src/dui2/client/file_nav_utils.py
@@ -137,10 +137,13 @@ class PathButtons(QWidget):
             path_str = "/"
 
         parent_dir_path = None
+
+        print("new_list =", new_list)
+
         for dir_name in new_list[:-1]:
             new_butt = QPushButton(dir_name)
             if dir_name == "":
-                logging.info("empty dir_name")
+                print("\n empty dir_name \n")
                 new_butt.setIcon(self._root_icon)
 
             else:
@@ -364,6 +367,9 @@ class FileBrowser(QDialog):
 
         for single_dir in rest_of_path.split("/"):
             parents_list.append(single_dir)
+
+        if parents_list[0:2] == ["", ""]:
+            parents_list = parents_list[1:]
 
         self.path_bar.update_list(parents_list)
 

--- a/src/dui2/client/file_nav_utils.py
+++ b/src/dui2/client/file_nav_utils.py
@@ -168,7 +168,6 @@ class PathButtons(QWidget):
 
         self.lst_butt.append(new_lab)
         self.main_h_lay.addWidget(new_lab)
-        logging.debug("parent_dir_path :::" + str(parent_dir_path) + ":::")
         return parent_dir_path
 
     def dir_clicked(self):
@@ -208,9 +207,6 @@ class PathBar(QWidget):
 
     def up_dir(self, next_path):
         if self.par_dir is not None:
-
-            logging.debug("next_path :::" + str(next_path) + ":::")
-
             self.clicked_up_dir.emit(next_path)
 
 
@@ -321,9 +317,6 @@ class FileBrowser(QDialog):
         self.lst_vw =  MyDirView_list()
 
         self.root_limit_path = limit_path
-        #self.root_limit_path = "/"
-        logging.debug("self.root_limit_path :::" + str(self.root_limit_path) + ":::")
-
         self.build_content(path_ini)
 
         self.lst_vw.file_clicked.connect(self.fill_clik)
@@ -355,8 +348,6 @@ class FileBrowser(QDialog):
         self.show()
 
     def build_content(self, path_in):
-        logging.debug("path_in :::" + str(path_in) + ":::")
-
         self.curr_path = path_in
         system = platform.system()
         if system == "Windows":
@@ -371,11 +362,7 @@ class FileBrowser(QDialog):
         self.refresh_content()
 
     def build_paren_list(self):
-
-        logging.debug("self.root_limit_path:::" + str(self.root_limit_path) + ":::")
         parents_list = [self.root_limit_path[:-1]]
-        logging.debug("self.curr_path :::" + str(self.curr_path) + ":::")
-
         len_lim = len(self.root_limit_path)
         if len_lim > 1:
             rest_of_path = self.curr_path[len_lim:]
@@ -383,15 +370,12 @@ class FileBrowser(QDialog):
         else:
             rest_of_path = self.curr_path
 
-        logging.debug("rest_of_path" + str(rest_of_path) + ":::")
-
         try:
             if rest_of_path[-1] == "/" or rest_of_path[-1] == "\\":
-                logging.debug("cutting " + os.sep + "from:" + str(rest_of_path))
                 rest_of_path = rest_of_path[:-1]
 
         except IndexError:
-            logging.debug("here IndexError")
+            logging.debug("here IndexError, empty path")
             rest_of_path = ""
 
         system = platform.system()

--- a/src/dui2/client/file_nav_utils.py
+++ b/src/dui2/client/file_nav_utils.py
@@ -233,6 +233,7 @@ class ReqDirList(QThread):
 
             except IndexError:
                 curr_path = ""
+
         else:
             # this is for unix style OS
             try:
@@ -358,7 +359,13 @@ class FileBrowser(QDialog):
         except IndexError:
             rest_of_path = ""
 
-        rest_of_path.replace("/", "\\")
+        system = platform.system()
+        if system == "Windows":
+            rest_of_path.replace("/", "\\")
+
+        else:
+            rest_of_path.replace("\\", "/")
+
 
         for single_dir in rest_of_path.split(os.sep):
             parents_list.append(single_dir)

--- a/src/dui2/client/file_nav_utils.py
+++ b/src/dui2/client/file_nav_utils.py
@@ -151,7 +151,7 @@ class PathButtons(QWidget):
                 new_butt.setIcon(self._root_icon)
 
             else:
-                path_str += dir_name + "/"
+                path_str += dir_name + os.sep
 
             new_butt.own_path = path_str
             parent_dir_path = str(path_str)
@@ -224,12 +224,12 @@ class ReqDirList(QThread):
         if system == "Windows":
             #test for windows
             try:
-                if curr_path[-1] != "/":
-                    curr_path += "/"
-
-                elif curr_path[-1] != "\\":
+                if(
+                    ( not curr_path.endswith("/") )
+                        and
+                    ( not curr_path.endswith("\\") )
+                ):
                     curr_path += "\\"
-
 
             except IndexError:
                 curr_path = ""
@@ -358,7 +358,9 @@ class FileBrowser(QDialog):
         except IndexError:
             rest_of_path = ""
 
-        for single_dir in rest_of_path.split("/"):
+        rest_of_path.replace("/", "\\")
+
+        for single_dir in rest_of_path.split(os.sep):
             parents_list.append(single_dir)
 
         if parents_list[0:2] == ["", ""]:

--- a/src/dui2/client/file_nav_utils.py
+++ b/src/dui2/client/file_nav_utils.py
@@ -42,13 +42,11 @@ def get_number_from_string(dict_in):
 
 
 def f_key(dic_in):
-    #return dic_in['name']
     return dic_in['isdir']
 
 
 def sort_dict_list(lst_in, key_in):
-    lst_out = sorted(lst_in, key=key_in)
-    return lst_out
+    return sorted(lst_in, key=key_in)
 
 
 class MyDirView_list(QListWidget):
@@ -144,12 +142,7 @@ class PathButtons(QWidget):
             else:
                 path_str = ""
 
-
-        print("\n root_limit_path =", root_limit_path, "\n")
-
         parent_dir_path = None
-
-        print("new_list =", new_list)
 
         for dir_name in new_list[:-1]:
             new_butt = QPushButton(dir_name)
@@ -249,8 +242,6 @@ class ReqDirList(QThread):
             except IndexError:
                 curr_path = "/"
 
-        print("curr_path(ReqDirList)", curr_path)
-
         self.curr_path = str(curr_path)
 
     def run(self):
@@ -323,12 +314,6 @@ class FileBrowser(QDialog):
         self.lst_vw =  MyDirView_list()
 
         self.root_limit_path = limit_path
-        #FIXME the previous line was how this was conceived
-        #self.root_limit_path = ""
-
-        print("self.root_limit_path =", self.root_limit_path)
-
-        #self.build_content("")
         self.build_content(path_ini)
 
         self.lst_vw.file_clickled.connect(self.fill_clik)
@@ -360,9 +345,6 @@ class FileBrowser(QDialog):
         self.show()
 
     def build_content(self, path_in):
-
-        print("path_in =", path_in)
-
         self.curr_path = path_in
         self.refresh_content()
 
@@ -425,9 +407,6 @@ class FileBrowser(QDialog):
         self.status_label.setText(" ")
         self.label_pos = -1
         self.refresh_sorted1()
-
-        print("self.curr_path(done_requesting)", self.curr_path)
-
         self.imp_dir_path.setText(
             str(self.curr_path)
         )

--- a/src/dui2/client/file_nav_utils.py
+++ b/src/dui2/client/file_nav_utils.py
@@ -203,12 +203,22 @@ class ReqDirList(QThread):
         super(ReqDirList, self).__init__()
         self.my_handler = my_handler
         self.show_hidden = show_hidden
+        # this is for unix style OS
+        '''
         try:
             if curr_path[-1] != "/":
                 curr_path += "/"
 
         except IndexError:
             curr_path = "/"
+        '''
+        #test for windows
+        try:
+            if curr_path[-1] != "/":
+                curr_path += "/"
+
+        except IndexError:
+            curr_path = ""
 
         self.curr_path = str(curr_path)
 
@@ -313,6 +323,9 @@ class FileBrowser(QDialog):
         self.show()
 
     def build_content(self, path_in):
+
+        print("path_in =", path_in)
+
         self.curr_path = path_in
         self.refresh_content()
 

--- a/src/dui2/client/file_nav_utils.py
+++ b/src/dui2/client/file_nav_utils.py
@@ -22,7 +22,7 @@ copyright (c) CCP4 - DLS
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 
-import sys, os, logging, platform
+import os, logging, platform
 
 from dui2.shared_modules.qt_libs import *
 
@@ -50,11 +50,11 @@ def sort_dict_list(lst_in, key_in):
 
 
 class MyDirView_list(QListWidget):
-    file_clickled = Signal(dict)
+    file_clicked = Signal(dict)
     def __init__(self, parent = None):
         super(MyDirView_list, self).__init__(parent)
-        self.itemClicked.connect(self.someting_click)
-        self.itemDoubleClicked.connect(self.clicked_twise)
+        self.itemClicked.connect(self.something_clicked)
+        self.itemDoubleClicked.connect(self.clicked_twice)
         self.setWrapping(True)
         self.setResizeMode(QListView.Adjust)
         DirPixMapi = getattr(QStyle, 'SP_DirIcon')
@@ -91,15 +91,15 @@ class MyDirView_list(QListWidget):
         for tst_item in self.items_list:
             self.addItem(tst_item)
 
-    def someting_click(self, item):
-        self.file_clickled.emit({"isdir":item.f_isdir, "path":item.f_path})
+    def something_clicked(self, item):
+        self.file_clicked.emit({"isdir":item.f_isdir, "path":item.f_path})
 
-    def clicked_twise(self, item):
-        self.someting_click(item)
+    def clicked_twice(self, item):
+        self.something_clicked(item)
 
 
 class PathButtons(QWidget):
-    up_dir_clickled = Signal(str)
+    up_dir_clicked = Signal(str)
     def __init__(self, parent = None):
         super(PathButtons, self).__init__()
 
@@ -174,7 +174,7 @@ class PathButtons(QWidget):
     def dir_clicked(self):
         next_path = str(self.sender().own_path)
         print("next_path =", next_path)
-        self.up_dir_clickled.emit(next_path)
+        self.up_dir_clicked.emit(next_path)
 
 
 class PathBar(QWidget):
@@ -183,7 +183,7 @@ class PathBar(QWidget):
         super(PathBar, self).__init__(parent)
         main_h_layout = QHBoxLayout()
         self.path_buttons = PathButtons(self)
-        self.path_buttons.up_dir_clickled.connect(self.up_dir)
+        self.path_buttons.up_dir_clicked.connect(self.up_dir)
         self.scroll_path = QScrollArea()
         self.scroll_path.setWidgetResizable(True)
         self.scroll_path.setWidget(self.path_buttons)
@@ -320,7 +320,7 @@ class FileBrowser(QDialog):
         self.root_limit_path = limit_path
         self.build_content(path_ini)
 
-        self.lst_vw.file_clickled.connect(self.fill_clik)
+        self.lst_vw.file_clicked.connect(self.fill_clik)
         main_v_layout.addWidget(self.lst_vw)
 
         low_h_layout = QHBoxLayout()
@@ -364,11 +364,10 @@ class FileBrowser(QDialog):
 
         system = platform.system()
         if system == "Windows":
-            rest_of_path.replace("/", "\\")
+            rest_of_path = rest_of_path.replace("/", "\\")
 
         else:
-            rest_of_path.replace("\\", "/")
-
+            rest_of_path = rest_of_path.replace("\\", "/")
 
         for single_dir in rest_of_path.split(os.sep):
             parents_list.append(single_dir)
@@ -448,7 +447,7 @@ class FileBrowser(QDialog):
         self.typed_path = None
 
     def open_file(self):
-        if self.typed_path != None:
+        if self.typed_path is not None:
             self.build_content(self.typed_path)
 
         else:

--- a/src/dui2/client/file_nav_utils.py
+++ b/src/dui2/client/file_nav_utils.py
@@ -263,7 +263,7 @@ class ReqDirList(QThread):
 class FileBrowser(QDialog):
     select_done = Signal(str, bool)
     def __init__(
-        self, parent = None, path_ini = None, limit_path = None,
+        self, parent = None, path_ini = "", limit_path = None,
         only_dir = False, runner_handler = None
     ):
         super(FileBrowser, self).__init__(parent)

--- a/src/dui2/client/file_nav_utils.py
+++ b/src/dui2/client/file_nav_utils.py
@@ -217,6 +217,10 @@ class ReqDirList(QThread):
             if curr_path[-1] != "/":
                 curr_path += "/"
 
+            elif curr_path[-1] != "\\":
+                curr_path += "\\"
+
+
         except IndexError:
             curr_path = ""
 
@@ -333,7 +337,7 @@ class FileBrowser(QDialog):
         parents_list = [self.root_limit_path[:-1]]
         rest_of_path = self.curr_path[len(self.root_limit_path):]
         try:
-            if rest_of_path[-1] == "/":
+            if rest_of_path[-1] == "/" or rest_of_path[-1] == "\\":
                 rest_of_path = rest_of_path[:-1]
 
         except IndexError:

--- a/src/dui2/client/file_nav_utils.py
+++ b/src/dui2/client/file_nav_utils.py
@@ -22,7 +22,7 @@ copyright (c) CCP4 - DLS
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 
-import sys, os, logging
+import sys, os, logging, platform
 
 from dui2.shared_modules.qt_libs import *
 
@@ -205,33 +205,30 @@ class ReqDirList(QThread):
         super(ReqDirList, self).__init__()
         self.my_handler = my_handler
         self.show_hidden = show_hidden
-        # this is for unix style OS
-        '''
-        try:
-            if curr_path[-1] != "/":
-                curr_path += "/"
 
-        except IndexError:
-            curr_path = "/"
-        '''
-        #test for windows
+        system = platform.system()
+        if system == "Windows":
+            #test for windows
+            try:
+                if curr_path[-1] != "/":
+                    curr_path += "/"
+
+                elif curr_path[-1] != "\\":
+                    curr_path += "\\"
+
+
+            except IndexError:
+                curr_path = ""
+        else:
+            # this is for unix style OS
+            try:
+                if curr_path[-1] != "/":
+                    curr_path += "/"
+
+            except IndexError:
+                curr_path = "/"
 
         print("curr_path(ReqDirList)", curr_path)
-
-        try:
-            if curr_path[-1] != "/":
-                curr_path += "/"
-
-                print("here 1")
-
-            elif curr_path[-1] != "\\":
-                curr_path += "\\"
-
-                print("here 2")
-
-
-        except IndexError:
-            curr_path = ""
 
         self.curr_path = str(curr_path)
 

--- a/src/dui2/client/file_nav_utils.py
+++ b/src/dui2/client/file_nav_utils.py
@@ -137,7 +137,9 @@ class PathButtons(QWidget):
                 logging.info("empty dir_name")
                 new_butt.setIcon(self._root_icon)
 
-            path_str += dir_name + "/"
+            else:
+                path_str += dir_name + "/"
+
             new_butt.own_path = path_str
             parent_dir_path = str(path_str)
             new_butt.clicked.connect(self.dir_clicked)
@@ -213,12 +215,19 @@ class ReqDirList(QThread):
             curr_path = "/"
         '''
         #test for windows
+
+        print("curr_path(ReqDirList)", curr_path)
+
         try:
             if curr_path[-1] != "/":
                 curr_path += "/"
 
+                print("here 1")
+
             elif curr_path[-1] != "\\":
                 curr_path += "\\"
+
+                print("here 2")
 
 
         except IndexError:
@@ -254,7 +263,7 @@ class ReqDirList(QThread):
 class FileBrowser(QDialog):
     select_done = Signal(str, bool)
     def __init__(
-        self, parent = None, path_ini = "/", limit_path = "/",
+        self, parent = None, path_ini = None, limit_path = None,
         only_dir = False, runner_handler = None
     ):
         super(FileBrowser, self).__init__(parent)
@@ -295,7 +304,12 @@ class FileBrowser(QDialog):
 
         self.lst_vw =  MyDirView_list()
 
-        self.root_limit_path = limit_path
+        #self.root_limit_path = limit_path
+        #FIXME the previous line was how this was conceived
+        self.root_limit_path = ""
+
+        print("self.root_limit_path =", self.root_limit_path)
+
         self.build_content(path_ini)
 
         self.lst_vw.file_clickled.connect(self.fill_clik)
@@ -381,6 +395,9 @@ class FileBrowser(QDialog):
             self.OpenButton.setEnabled(True)
 
     def new_path_text(self, new_path):
+
+
+
         self.typed_path = str(new_path)
 
     def done_requesting(self, lst_dir):
@@ -388,6 +405,9 @@ class FileBrowser(QDialog):
         self.status_label.setText(" ")
         self.label_pos = -1
         self.refresh_sorted1()
+
+        print("self.curr_path(done_requesting)", self.curr_path)
+
         self.imp_dir_path.setText(
             str(self.curr_path)
         )

--- a/src/dui2/client/file_nav_utils.py
+++ b/src/dui2/client/file_nav_utils.py
@@ -147,7 +147,7 @@ class PathButtons(QWidget):
         for dir_name in new_list[:-1]:
             new_butt = QPushButton(dir_name)
             if dir_name == "":
-                print("\n empty dir_name \n")
+                logging.info("empty dir_name(file_nav_utils)")
                 new_butt.setIcon(self._root_icon)
 
             else:
@@ -173,7 +173,7 @@ class PathButtons(QWidget):
 
     def dir_clicked(self):
         next_path = str(self.sender().own_path)
-        print("next_path =", next_path)
+        logging.info("next_path =" + str(next_path))
         self.up_dir_clicked.emit(next_path)
 
 
@@ -411,7 +411,7 @@ class FileBrowser(QDialog):
 
     def new_path_text(self, new_path):
         self.typed_path = str(new_path)
-        print("\n FileBrowser.typed_path =", self.typed_path, "\n")
+        logging.info("FileBrowser.typed_path =" + str(self.typed_path))
 
     def done_requesting(self, lst_dir):
         self.lst_vw.enter_list(lst_in = lst_dir)

--- a/src/dui2/client/file_nav_utils.py
+++ b/src/dui2/client/file_nav_utils.py
@@ -304,12 +304,13 @@ class FileBrowser(QDialog):
 
         self.lst_vw =  MyDirView_list()
 
-        #self.root_limit_path = limit_path
+        self.root_limit_path = limit_path
         #FIXME the previous line was how this was conceived
-        self.root_limit_path = ""
+        #self.root_limit_path = ""
 
         print("self.root_limit_path =", self.root_limit_path)
 
+        #self.build_content("")
         self.build_content(path_ini)
 
         self.lst_vw.file_clickled.connect(self.fill_clik)

--- a/src/dui2/client/q_object.py
+++ b/src/dui2/client/q_object.py
@@ -759,7 +759,7 @@ class MainObject(QObject):
             self.nxt_key_clicked("import")
             data_init = IniData()
             import_init = data_init.get_import_init()
-            if import_init != "None":
+            if import_init != None:
                 self.imp_widg.set_selection(str(import_init), isdir = True)
 
         else:

--- a/src/dui2/client/simpler_param_widgets.py
+++ b/src/dui2/client/simpler_param_widgets.py
@@ -361,9 +361,12 @@ class ImportWidget(QWidget):
 
     def set_selection(self, str_select, isdir):
         logging.info("isdir(set_selection) =" + str(isdir))
+
+
         if str_select != "":
             self.dir_selected = isdir
             if self.dir_selected:
+                print("str_select =", str_select)
                 self.imp_txt.setText(str_select)
 
             else:
@@ -380,6 +383,7 @@ class ImportWidget(QWidget):
                     elif self.rad_but_img_file.isChecked():
                         file_path_str = build_template(str_select)[1]
 
+                print("file_path_str =",file_path_str)
                 self.imp_txt.setText(file_path_str)
 
             self.line_changed()
@@ -414,7 +418,6 @@ class ImportWidget(QWidget):
             params_in = cmd, main_handler = self.runner_handler
         )
         dic_str = lst_req.result_out()
-
         path_serv_limit = str(dic_str[0])
         str_already_there = from_path_2_dir(str(self.imp_txt.text()))
 
@@ -423,6 +426,8 @@ class ImportWidget(QWidget):
 
         else:
             init_path = path_serv_limit
+
+        print("init_path = ", init_path)
 
         if(
             self.rad_but_template.isChecked() or

--- a/src/dui2/client/simpler_param_widgets.py
+++ b/src/dui2/client/simpler_param_widgets.py
@@ -311,17 +311,6 @@ class ImportWidget(QWidget):
 
         self.rad_but_template.setChecked(True)
 
-        '''
-        self.diag_rad_butt_vbox = QVBoxLayout()
-        group2 = QButtonGroup(self)
-        self.rad_but_dui_diag = QRadioButton("Dui2 dialog")
-        self.rad_but_sys_diag = QRadioButton("System dialog")
-        group2.addButton(self.rad_but_dui_diag)
-        group2.addButton(self.rad_but_sys_diag)
-        self.diag_rad_butt_vbox.addWidget(self.rad_but_dui_diag)
-        self.diag_rad_butt_vbox.addWidget(self.rad_but_sys_diag)
-        '''
-
         self.imp_txt.textChanged.connect(self.line_changed)
         self.imp_extra_txt.textChanged.connect(self.line_changed)
         self.open_butt.clicked.connect(self.open_dir_widget)
@@ -394,27 +383,6 @@ class ImportWidget(QWidget):
             logging.info("no selection ( canceled? )")
 
     def open_dir_widget(self):
-        '''
-        if self.rad_but_sys_diag.isChecked():
-            if(
-                self.rad_but_template.isChecked() or
-                self.rad_but_img_file.isChecked()
-            ):
-                file_in_path = QFileDialog.getOpenFileName(
-                    parent = self, caption = "Open Image File",
-                    dir = "/", filter = "Files (*.*)"
-                )[0]
-                self.set_selection(str_select = str(file_in_path), isdir = False)
-
-            elif self.rad_but_directory.isChecked():
-                dir_path = QFileDialog.getExistingDirectory(
-                    parent = self, caption = "Open Directory", dir = "/"
-                )
-                self.set_selection(str_select = str(dir_path), isdir = True)
-
-        else:
-        '''
-
         cmd = {"nod_lst":"", "cmd_str":["dir_path"]}
         lst_req = get_req_json_dat(
             params_in = cmd, main_handler = self.runner_handler
@@ -454,18 +422,6 @@ class ImportWidget(QWidget):
         self.dist_text_in.setText("Auto")
         self.check_shadow.setChecked(False)
         self.rad_but_img_file.setChecked(True)
-        '''
-        if not self.run_local:
-            self.rad_but_sys_diag.setEnabled(False)
-
-        if self.run_local and self.win_exe:
-            self.rad_but_sys_diag.setChecked(True)
-            self.rad_but_dui_diag.setEnabled(False)
-
-        else:
-            self.rad_but_dui_diag.setChecked(True)
-        '''
-
         self.do_emit = True
 
     def set_ed_pars(self):

--- a/src/dui2/client/simpler_param_widgets.py
+++ b/src/dui2/client/simpler_param_widgets.py
@@ -175,9 +175,8 @@ class SimpleParamTab(QWidget):
 
 
 def build_template(str_path_in):
-    logging.info("time to build template from:" + str(str_path_in))
-
     found_a_digit = False
+    logging.info("building template from: " + str(str_path_in))
     for pos, single_char in enumerate(str_path_in):
         if single_char in "0123456789":
             last_digit_pos = pos
@@ -196,11 +195,13 @@ def build_template(str_path_in):
         star_str = str_path_in[
             0:begin_digit_pos + 1
         ] + "*" + str_path_in[last_digit_pos + 1:]
-
         return template_str, star_str
 
     else:
-        return None, 0
+        err_msg = "Non image file selected"
+        print("\n" + err_msg + "\n")
+        logging.info(err_msg)
+        return "", ""
 
 
 def get_lst_par_from_str(str_in):
@@ -368,7 +369,6 @@ class ImportWidget(QWidget):
         if str_select != "":
             self.dir_selected = isdir
             if self.dir_selected:
-                print("str_select =", str_select)
                 self.imp_txt.setText(str_select)
 
             else:
@@ -385,7 +385,7 @@ class ImportWidget(QWidget):
                     elif self.rad_but_img_file.isChecked():
                         file_path_str = build_template(str_select)[1]
 
-                print("file_path_str =",file_path_str)
+                logging.info("file_path_str =" + str(file_path_str))
                 self.imp_txt.setText(file_path_str)
 
             self.line_changed()
@@ -428,8 +428,6 @@ class ImportWidget(QWidget):
 
         else:
             init_path = path_serv_limit
-
-        print("init_path = ", init_path)
 
         if(
             self.rad_but_template.isChecked() or
@@ -597,7 +595,7 @@ class ImportWidget(QWidget):
                     self.dist_text_in.setText(str(par_dic["value"]))
 
         except IndexError:
-            print(" Not copying parameters from node (Index err catch )")
+            logging.info(" Not copying parameters from node (Index err catch )")
             self.imp_txt.setText("")
             self.imp_extra_txt.setText("")
 

--- a/src/dui2/client/simpler_param_widgets.py
+++ b/src/dui2/client/simpler_param_widgets.py
@@ -310,6 +310,7 @@ class ImportWidget(QWidget):
 
         self.rad_but_template.setChecked(True)
 
+        '''
         self.diag_rad_butt_vbox = QVBoxLayout()
         group2 = QButtonGroup(self)
         self.rad_but_dui_diag = QRadioButton("Dui2 dialog")
@@ -318,6 +319,7 @@ class ImportWidget(QWidget):
         group2.addButton(self.rad_but_sys_diag)
         self.diag_rad_butt_vbox.addWidget(self.rad_but_dui_diag)
         self.diag_rad_butt_vbox.addWidget(self.rad_but_sys_diag)
+        '''
 
         self.imp_txt.textChanged.connect(self.line_changed)
         self.imp_extra_txt.textChanged.connect(self.line_changed)
@@ -341,7 +343,7 @@ class ImportWidget(QWidget):
 
         self.open_diag_hbox = QHBoxLayout()
         self.open_diag_hbox.addWidget(self.open_butt)
-        self.open_diag_hbox.addLayout(self.diag_rad_butt_vbox)
+        #self.open_diag_hbox.addLayout(self.diag_rad_butt_vbox)
         self.main_vbox.addLayout(self.open_diag_hbox)
 
         self.main_vbox.addStretch()
@@ -454,6 +456,7 @@ class ImportWidget(QWidget):
         self.dist_text_in.setText("Auto")
         self.check_shadow.setChecked(False)
         self.rad_but_img_file.setChecked(True)
+        '''
         if not self.run_local:
             self.rad_but_sys_diag.setEnabled(False)
 
@@ -463,6 +466,7 @@ class ImportWidget(QWidget):
 
         else:
             self.rad_but_dui_diag.setChecked(True)
+        '''
 
         self.do_emit = True
 

--- a/src/dui2/client/simpler_param_widgets.py
+++ b/src/dui2/client/simpler_param_widgets.py
@@ -388,6 +388,7 @@ class ImportWidget(QWidget):
             logging.info("no selection ( canceled? )")
 
     def open_dir_widget(self):
+        '''
         if self.rad_but_sys_diag.isChecked():
             if(
                 self.rad_but_template.isChecked() or
@@ -406,38 +407,39 @@ class ImportWidget(QWidget):
                 self.set_selection(str_select = str(dir_path), isdir = True)
 
         else:
+        '''
 
-            cmd = {"nod_lst":"", "cmd_str":["dir_path"]}
-            lst_req = get_req_json_dat(
-                params_in = cmd, main_handler = self.runner_handler
-            )
-            dic_str = lst_req.result_out()
+        cmd = {"nod_lst":"", "cmd_str":["dir_path"]}
+        lst_req = get_req_json_dat(
+            params_in = cmd, main_handler = self.runner_handler
+        )
+        dic_str = lst_req.result_out()
 
-            path_serv_limit = str(dic_str[0])
-            str_already_there = from_path_2_dir(str(self.imp_txt.text()))
+        path_serv_limit = str(dic_str[0])
+        str_already_there = from_path_2_dir(str(self.imp_txt.text()))
 
-            if path_serv_limit in str_already_there:
-                init_path = str_already_there
+        if path_serv_limit in str_already_there:
+            init_path = str_already_there
 
-            else:
-                init_path = path_serv_limit
+        else:
+            init_path = path_serv_limit
 
-            if(
-                self.rad_but_template.isChecked() or
-                self.rad_but_img_file.isChecked()
-            ):
-                only_dir_bool = False
+        if(
+            self.rad_but_template.isChecked() or
+            self.rad_but_img_file.isChecked()
+        ):
+            only_dir_bool = False
 
-            elif self.rad_but_directory.isChecked():
-                only_dir_bool = True
+        elif self.rad_but_directory.isChecked():
+            only_dir_bool = True
 
-            self.open_widget = FileBrowser(
-                parent = self, path_ini = init_path,
-                limit_path = path_serv_limit, only_dir = only_dir_bool,
-                runner_handler = self.runner_handler
-            )
-            self.open_widget.resize(self.open_widget.size() * 2)
-            self.open_widget.select_done.connect(self.set_selection)
+        self.open_widget = FileBrowser(
+            parent = self, path_ini = init_path,
+            limit_path = path_serv_limit, only_dir = only_dir_bool,
+            runner_handler = self.runner_handler
+        )
+        self.open_widget.resize(self.open_widget.size() * 2)
+        self.open_widget.select_done.connect(self.set_selection)
 
     def reset_pars(self):
         self.do_emit = False

--- a/src/dui2/server/data_n_json.py
+++ b/src/dui2/server/data_n_json.py
@@ -557,9 +557,6 @@ def get_info_data(uni_cmd, cmd_dict, step_list):
             logging.info("limit_path =" + str( limit_path))
             if reqt_path[0:len(limit_path)] == limit_path:
                 try:
-                    ''' TODO consider replacing listdir with scandir,
-                     maybe will make navigation faster but will need to
-                    rewrite the next 20 lines, and test '''
                     f_name_list =  sorted(os.listdir(reqt_path))
                     dict_list = []
                     for f_name in f_name_list:

--- a/src/dui2/server/data_n_json.py
+++ b/src/dui2/server/data_n_json.py
@@ -576,8 +576,6 @@ def get_info_data(uni_cmd, cmd_dict, step_list):
 
                 print("reqt_path=", reqt_path)
 
-
-
                 try:
 
                     if reqt_path == "\\" or reqt_path == "":
@@ -589,6 +587,7 @@ def get_info_data(uni_cmd, cmd_dict, step_list):
                         print("dict_list =", dict_list)
 
                     else:
+                        reqt_path = reqt_path.lstrip("\\")
                         f_name_list = sorted(os.listdir(reqt_path))
 
                         dict_list = []

--- a/src/dui2/server/data_n_json.py
+++ b/src/dui2/server/data_n_json.py
@@ -566,7 +566,14 @@ def get_info_data(uni_cmd, cmd_dict, step_list):
         #and consequently go elsewhere
 
         try:
-            reqt_path = str(uni_cmd[1].replace("/", os.sep))
+            try:
+                reqt_path = str(uni_cmd[1].replace("/", os.sep))
+
+            except IndexError:
+                reqt_path = ""
+                print("empty path string to navigate, assuming (root)")
+
+            print("reqt_path =", reqt_path)
 
             data_init = IniData()
             limit_path = str(data_init.get_lim_path())

--- a/src/dui2/server/data_n_json.py
+++ b/src/dui2/server/data_n_json.py
@@ -578,7 +578,7 @@ def get_info_data(uni_cmd, cmd_dict, step_list):
             limit_path = str(data_init.get_lim_path())
             logging.info("reqt_path =" + str(reqt_path))
             logging.info("limit_path =" + str( limit_path))
-            if reqt_path[0:len(limit_path)] == limit_path:
+            if limit_path == "" or reqt_path.startswith(limit_path):
                 logging.info("reqt_path=" + str(reqt_path))
                 try:
 

--- a/src/dui2/server/data_n_json.py
+++ b/src/dui2/server/data_n_json.py
@@ -573,9 +573,7 @@ def get_info_data(uni_cmd, cmd_dict, step_list):
             logging.info("reqt_path =" + str(reqt_path))
             logging.info("limit_path =" + str( limit_path))
             if reqt_path[0:len(limit_path)] == limit_path:
-
-                print("reqt_path=", reqt_path)
-
+                logging.info("reqt_path=" + str(reqt_path))
                 try:
 
                     if reqt_path == "\\" or reqt_path == "":
@@ -584,7 +582,7 @@ def get_info_data(uni_cmd, cmd_dict, step_list):
                         for f_name in f_name_list:
                             dict_list.append({"fname": f_name, "isdir":True})
 
-                        print("dict_list =", dict_list)
+                        logging.info("dict_list =" + str(dict_list))
 
                     else:
                         reqt_path = reqt_path.lstrip("\\")
@@ -605,13 +603,10 @@ def get_info_data(uni_cmd, cmd_dict, step_list):
                     return_list = []
 
             else:
-                print(
-                    "Not allowing get_dir_ls >> ", reqt_path,
-                    " when limit_path =", limit_path
-                )
-                err_msg = "permission denied by Dui2 server err catch, " + \
-                "attempt to open not allowed path, not sending file list"
-                logging.info(err_msg)
+                msg_err = "Not allowing get_dir_ls >> " + str(reqt_path) + \
+                " when limit_path =" + str(limit_path)
+                print(msg_err)
+                logging.info(msg_err)
                 return_list = []
 
         except FileNotFoundError:

--- a/src/dui2/server/data_n_json.py
+++ b/src/dui2/server/data_n_json.py
@@ -571,10 +571,9 @@ def get_info_data(uni_cmd, cmd_dict, step_list):
 
             except IndexError:
                 reqt_path = ""
-                print("empty path string to navigate, assuming (root)")
+                logging.info("empty path string to navigate, assuming (root)")
 
-            print("reqt_path =", reqt_path)
-
+            logging.info("reqt_path =" + str(reqt_path))
             data_init = IniData()
             limit_path = str(data_init.get_lim_path())
             logging.info("reqt_path =" + str(reqt_path))

--- a/src/dui2/server/data_n_json.py
+++ b/src/dui2/server/data_n_json.py
@@ -21,7 +21,8 @@ copyright (c) CCP4 - DLS
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-import json, os, glob, logging
+import json, os, glob, logging, platform
+
 import subprocess, shutil
 
 import requests
@@ -101,6 +102,22 @@ def get_dict_from_str_with_pairs(str_in):
         dict_w_data[str(pair[0])] = str(pair[1])
 
     return dict_w_data
+
+def get_drives():
+    system = platform.system()
+
+    if system == "Windows":
+        import ctypes, string
+        drives = []
+        bitmask = ctypes.windll.kernel32.GetLogicalDrives()
+        for letter in string.ascii_uppercase:
+            if bitmask & 1:
+                drives.append(f"{letter}:\\")
+            bitmask >>= 1
+        return drives
+
+    else:
+        return sorted(os.listdir("/"))
 
 def get_info_data(uni_cmd, cmd_dict, step_list):
     return_list = []
@@ -556,14 +573,30 @@ def get_info_data(uni_cmd, cmd_dict, step_list):
             logging.info("reqt_path =" + str(reqt_path))
             logging.info("limit_path =" + str( limit_path))
             if reqt_path[0:len(limit_path)] == limit_path:
+
+                print("reqt_path=", reqt_path)
+
+
+
                 try:
-                    f_name_list =  sorted(os.listdir(reqt_path))
-                    dict_list = []
-                    for f_name in f_name_list:
-                        f_path = reqt_path + f_name
-                        f_isdir = os.path.isdir(f_path)
-                        file_dict = {"fname": f_name, "isdir":f_isdir}
-                        dict_list.append(file_dict)
+
+                    if reqt_path == "\\" or reqt_path == "":
+                        f_name_list = get_drives()
+                        dict_list = []
+                        for f_name in f_name_list:
+                            dict_list.append({"fname": f_name, "isdir":True})
+
+                        print("dict_list =", dict_list)
+
+                    else:
+                        f_name_list = sorted(os.listdir(reqt_path))
+
+                        dict_list = []
+                        for f_name in f_name_list:
+                            f_path = reqt_path + f_name
+                            f_isdir = os.path.isdir(f_path)
+                            file_dict = {"fname": f_name, "isdir":f_isdir}
+                            dict_list.append(file_dict)
 
                     return_list = dict_list
 

--- a/src/dui2/server/init_first.py
+++ b/src/dui2/server/init_first.py
@@ -22,9 +22,9 @@ class IniData(object):
 
         global lim_pth
         lim_pth = init_param["limit_path"]
-        if lim_pth == None:
+        if lim_pth == None or lim_pth == "/":
             if init_param["windows_exe"].lower() == "true":
-                lim_pth = "c:\\"
+                lim_pth = ""
 
             else:
                 lim_pth = "/"

--- a/src/dui2/server/multi_node.py
+++ b/src/dui2/server/multi_node.py
@@ -1059,14 +1059,9 @@ class Runner(object):
             self.step_list.append(new_node)
 
     def set_dir_path(self, dir_path_in):
-
-        print("\ndir_path_in =", dir_path_in)
-
         if len(dir_path_in) > 1 and dir_path_in[-1] != os.sep:
             dir_path_in += os.sep
 
         self._dir_path = dir_path_in
-
-        print("\n self._dir_path =", self._dir_path, "\n")
 
 

--- a/src/dui2/server/multi_node.py
+++ b/src/dui2/server/multi_node.py
@@ -1059,11 +1059,14 @@ class Runner(object):
             self.step_list.append(new_node)
 
     def set_dir_path(self, dir_path_in):
-        if dir_path_in[-1] != os.sep:
+
+        print("\ndir_path_in =", dir_path_in)
+
+        if len(dir_path_in) > 1 and dir_path_in[-1] != os.sep:
             dir_path_in += os.sep
 
         self._dir_path = dir_path_in
 
-        print("\n\n self._dir_path =", self._dir_path, "\n\n")
+        print("\n self._dir_path =", self._dir_path, "\n")
 
 

--- a/src/dui2/server/run_server.py
+++ b/src/dui2/server/run_server.py
@@ -314,6 +314,8 @@ def main(par_def = None, connection_out = None):
             logging.info(msg_txt)
             print(msg_txt)
 
+    print("tree_lim_path(run_server) =", tree_lim_path)
+
     nodes_dir = "run_dui2_token_" + token_from_cli
     try:
         os.mkdir(nodes_dir)

--- a/src/dui2/server/run_server.py
+++ b/src/dui2/server/run_server.py
@@ -314,8 +314,6 @@ def main(par_def = None, connection_out = None):
             logging.info(msg_txt)
             print(msg_txt)
 
-    print("tree_lim_path(run_server) =", tree_lim_path)
-
     nodes_dir = "run_dui2_token_" + token_from_cli
     try:
         os.mkdir(nodes_dir)

--- a/src/dui2/server/run_server.py
+++ b/src/dui2/server/run_server.py
@@ -305,7 +305,7 @@ def main(par_def = None, connection_out = None):
         tree_lim_path = init_param["limit_path"]
         if tree_lim_path == None:
             if init_param["windows_exe"].lower() == "true":
-                tree_lim_path = "c:\\"
+                tree_lim_path = ""
 
             else:
                 tree_lim_path = "/"


### PR DESCRIPTION
**Cross-platform file browser fixes and code cleanup**
This PR improves the Dui2 file browser to work consistently on both Windows and Unix systems.

**Main changes:**

1. Fixed path handling in the file browser to correctly navigate drives and directories on Windows, while keeping Unix behaviour unchanged
2. Added get_drives() to enumerate available Windows drives when browsing from root
3. Fixed the limit_path security check to handle the case where no path restriction is set
4. Fixed several long-standing typos in signal and method names (file_clickled → file_clicked, up_dir_clickled → up_dir_clicked, someting_click → something_clicked, clicked_twise → clicked_twice)
5. Fixed a type comparison bug (!= "None" → is not None) in q_object.py
6. build_template() now returns "", "" instead of None, 0 when no image file is selected, avoiding unpacking errors in callers
7. Removed debug print() statements and excessive logging.debug calls added during development
8. Removed dead commented-out code (system dialog radio buttons)


**Tested on:** Windows and Linux (local mode)