### PR TITLE
Fix eval()-on-network-data security issue, remove busy-wait polling, add working-directory picker

### DIFF
--- a/IMPROVEMENT_SUGGESTIONS.md
+++ b/IMPROVEMENT_SUGGESTIONS.md
@@ -1,0 +1,68 @@
+# Improvement suggestions for `Dui2-ai-pr`
+
+Notes from comparing `luisodls/Dui2-ai-pr` against `ccp4/DUI2` (upstream), plus a
+general repo-hygiene pass. For personal study/reference — not yet actioned.
+
+## Status vs upstream
+
+`master` here is exactly `ccp4/DUI2`'s `master` (`694aa46`) plus 4 commits ahead,
+0 behind. Clean superset, no merge conflicts, no rebase needed.
+
+### The 4 commits ahead of upstream
+
+| Commit | What it does | Note |
+|---|---|---|
+| `d9e6ac0` removing eval for security reasons | Replaces `eval(right_side)` / `str(params)` with `json.loads`/`json.dumps` in 3 files (`img_view_threads_n_menus.py`, `data_n_json.py`, `img_view_utils.py`) | Genuinely good — `eval()` on data coming over the wire (client↔server) is a real code-injection risk. Strongest commit of the four. |
+| `7277e63` replacing while loop with thread.wait | Swaps a busy-wait loop for `thread.wait()` | Efficiency cleanup |
+| `8328b07` working-directory picker dialog | Lets the user pick a working dir via file dialog | UX feature |
+| `cf53956` log file relocation | Moves log file alongside the chosen dir | Small follow-up to the above |
+
+**Recommendation:** none of these are upstream yet. Especially the `eval()` fix —
+worth opening a PR to `ccp4/DUI2` for that one on its own rather than letting it
+sit only in the fork.
+
+## Repo hygiene (missing in both upstream and fork, but easy wins here)
+
+- **No `.gitignore`** — `__pycache__/*.pyc` currently sits untracked in the
+  working tree only by luck; one `git add -A` away from being committed. Add a
+  standard Python `.gitignore`.
+- **No CI** (`.github/workflows/`) — nothing runs tests or lint on push. Even a
+  minimal "install + pytest" GitHub Actions workflow signals the repo is
+  maintained, and gives the README something legitimate to badge.
+- **Tests exist but aren't wired up** — `src/dui2/client/tests/` has ~10 test
+  files but no `pytest.ini` / `conftest.py` / CI job actually running them.
+  Untested-looking tests read worse than no tests.
+- **`pyproject.toml` is missing standard metadata** — no `authors`, `readme`,
+  `license`, `classifiers`, or `urls` (Homepage/Repository/Issues). A GPL-2
+  `LICENSE` file exists but isn't declared in `pyproject.toml`.
+
+## Code-level smells (grepped across `src/`, ~17k LOC)
+
+- **233 `print()` calls** in production code vs. the `logging` module that's
+  already used elsewhere — inconsistent, and `print` can't be silenced/leveled
+  in production.
+- **53 TODO/FIXME/XXX** comments left in-tree — either resolve them or move
+  them to GitHub issues.
+- **25 wildcard `import *`** — hides what's actually imported, defeats linters.
+- **12 hardcoded `/home/`/`/Users/` absolute paths** — portability red flag.
+- **1 bare `except:`** — swallows everything including `KeyboardInterrupt`.
+- **Sprawling entry points** — `src/run_dui2*.py` (×4), `run_img_client.py`,
+  `run_img_server.py`, `run_multi_user_dui2_server.py`, `run_user_login.py`,
+  plus `all_local.py` / `all_local_all_ram.py` / `only_client.py` /
+  `only_server.py` inside the package — no doc anywhere explaining which is
+  canonical vs. legacy. A short "which script do I run" table in the README
+  would help a lot.
+- **Commit message style is inconsistent** (lowercase, informal — e.g. "adding
+  log file to dir re-location") — fine for personal work, but worth tightening
+  if this fork is meant to be reviewed or upstreamed.
+
+## Suggested priority order
+
+1. Add `.gitignore` (5 min, zero risk)
+2. Fill in `pyproject.toml` metadata (`license`, `readme`, `authors`, `urls`)
+   (10 min)
+3. Add a minimal CI workflow that installs the package and runs the existing
+   tests (30 min — biggest "looks maintained" signal)
+4. Open a PR upstream with the `eval()` security fix specifically — that's the
+   commit most worth getting merged
+5. Swap `print()` → `logging` and clean up the bare `except:` as time allows

--- a/src/dui2/all_local_all_ram.py
+++ b/src/dui2/all_local_all_ram.py
@@ -13,8 +13,7 @@ from dui2.server import multi_node
 from dui2.server.init_first import IniData as ServerIniData
 
 
-logging.basicConfig(filename='run_dui2_all_local_all_ram.log', level=logging.DEBUG)
-#FIXME: this opens a log file before the directory was chosen
+#logging.basicConfig(filename='run_dui2_all_local_all_ram.log', level=logging.DEBUG)
 
 def main():
     os.environ["QTWEBENGINE_CHROMIUM_FLAGS"] = "--no-sandbox"
@@ -56,7 +55,6 @@ def main():
 
         if dir_2_change != '':
             print("dir_2_change =", dir_2_change)
-            new_chdir = dir_2_change
 
         else:
             print("Canceled Operation")
@@ -125,6 +123,10 @@ def main():
         cmd_runner = multi_node.Runner(
             recovery_data = None, dat_ini = server_data_init
         )
+
+    log_path = os.path.join(dir_2_change, 'run_dui2_all_local_all_ram.log')
+    logging.basicConfig(filename=log_path, level=logging.DEBUG, force=True)
+
 
     logging.info("tree_ini_path(all_loca_all_ram) =" + str(tree_ini_path))
 

--- a/src/dui2/all_local_all_ram.py
+++ b/src/dui2/all_local_all_ram.py
@@ -33,7 +33,7 @@ def main():
 
     par_def = (
         ("chdir", None),
-        ("ask4dir", False),
+        ("ask4dir", "false"),
         ("limit_path", None),
         ("import_init", None),
         ("all_local", "true"),
@@ -49,16 +49,22 @@ def main():
     data_init.set_data(par_def = par_def)
     print("\n ask4dir =", init_param["ask4dir"], "\n")
     app = QApplication(sys.argv)
-    dir_2_change = None
-    if init_param["ask4dir"] is not False:
-        dir_2_change = QFileDialog.getExistingDirectory(caption = "Open Directory")
+
+    if init_param["ask4dir"] == "false":
+        print("Using same dir where Dui2 were invoked from as working dir")
+        dir_2_change = os.getcwd()
+
+    else:
+        dir_2_change = QFileDialog.getExistingDirectory(caption = "Chose working directory")
 
         if dir_2_change != '':
             print("dir_2_change =", dir_2_change)
 
         else:
             print("Canceled Operation")
-            sys.exit(1)
+            dir_2_change = os.getcwd()
+            #TODO consider interrupting here with the next t line
+            #sys.exit(1)
 
     format_utils.print_logo()
 

--- a/src/dui2/all_local_all_ram.py
+++ b/src/dui2/all_local_all_ram.py
@@ -14,11 +14,10 @@ from dui2.server.init_first import IniData as ServerIniData
 
 
 logging.basicConfig(filename='run_dui2_all_local_all_ram.log', level=logging.DEBUG)
+#FIXME: this opens a log file before the directory was chosen
 
 def main():
     os.environ["QTWEBENGINE_CHROMIUM_FLAGS"] = "--no-sandbox"
-
-    logging.info("platform.system()" + str(platform.system()))
 
     win_str = "false"
     if platform.system() == "Windows":
@@ -35,6 +34,7 @@ def main():
 
     par_def = (
         ("chdir", None),
+        ("ask4dir", False),
         ("limit_path", None),
         ("import_init", None),
         ("all_local", "true"),
@@ -43,22 +43,42 @@ def main():
         ("upload_mtz_url", "http://localhost:8080/"),
         ("cloudrun_id", "xxxx-xxxx-xxxx-xxxx"),
     )
+
+
+    init_param = format_utils.get_par(par_def, sys.argv[1:])
     data_init = IniData()
     data_init.set_data(par_def = par_def)
+    print("\n ask4dir =", init_param["ask4dir"], "\n")
+    app = QApplication(sys.argv)
+    dir_2_change = None
+    if init_param["ask4dir"] is not False:
+        dir_2_change = QFileDialog.getExistingDirectory(caption = "Open Directory")
+
+        if dir_2_change != '':
+            print("dir_2_change =", dir_2_change)
+            new_chdir = dir_2_change
+
+        else:
+            print("Canceled Operation")
+            sys.exit(1)
 
     format_utils.print_logo()
 
     server_data_init = ServerIniData()
     server_data_init.set_data(par_def = par_def)
 
-    tmp_dat_dir = format_utils.create_tmp_dir()
-
-    data_init.set_tmp_dir(tmp_dat_dir)
-
-    init_param = format_utils.get_par(par_def, sys.argv[1:])
-
     #TODO: check if the following line is useful
     run_local = True
+
+    if dir_2_change is not None:
+        try:
+            os.chdir(dir_2_change)
+
+        except FileNotFoundError:
+            print(
+                "unable to change to directory: ", dir_2_change,
+                "File Not Found Err Catch"
+            )
 
     if init_param["chdir"] is not None:
         try:
@@ -69,6 +89,9 @@ def main():
                 "unable to change to directory: ", init_param["chdir"],
                 "File Not Found Err Catch"
             )
+
+    tmp_dat_dir = format_utils.create_tmp_dir()
+    data_init.set_tmp_dir(tmp_dat_dir)
 
     nodes_dir = "run_dui2_nodes"
     try:
@@ -107,7 +130,6 @@ def main():
 
     cmd_runner.set_dir_path(tree_ini_path)
 
-    app = QApplication(sys.argv)
     m_gui_obj = all_local_gui_connector.MainGuiObject(
         parent = app, cmd_tree_runner = cmd_runner
     )

--- a/src/dui2/all_local_all_ram.py
+++ b/src/dui2/all_local_all_ram.py
@@ -47,7 +47,6 @@ def main():
     init_param = format_utils.get_par(par_def, sys.argv[1:])
     data_init = IniData()
     data_init.set_data(par_def = par_def)
-    print("\n ask4dir =", init_param["ask4dir"], "\n")
     app = QApplication(sys.argv)
 
     if init_param["ask4dir"] == "false":
@@ -58,7 +57,7 @@ def main():
         dir_2_change = QFileDialog.getExistingDirectory(caption = "Chose working directory")
 
         if dir_2_change != '':
-            print("dir_2_change =", dir_2_change)
+            print("Using ", dir_2_change, " as working dir")
 
         else:
             print("Canceled Operation")

--- a/src/dui2/client/exec_utils.py
+++ b/src/dui2/client/exec_utils.py
@@ -26,6 +26,8 @@ from dui2.shared_modules.qt_libs import *
 
 import requests, json, os, sys, zlib, logging
 
+from threading import Event
+
 from dui2.client.gui_utils import AdvancedParameters, widgets_defs
 from dui2.client.init_firts import IniData
 from dui2.shared_modules import format_utils
@@ -61,26 +63,23 @@ class get_request_shot(QObject):
                 )
                 self.to_return = None
 
-            self.done = True
-
+            self._done = Event()
+            self._done.set()
         else:
-            self.done = False
+            self._done = Event()
             main_handler.get_from_main_dui(params_in, self)
-            #self.to_return = None
 
     def get_it_str(self, data_comming):
         self.to_return = data_comming
-        self.done = True
+        self._done.set()
 
     def get_it_bin(self, data_comming):
         logging.info("type(data_comming) = " + str(type(data_comming)))
         self.to_return = data_comming
-        self.done = True
+        self._done.set()
 
     def result_out(self):
-        while not self.done:
-            QThread.msleep(10)
-
+        self._done.wait()
         return self.to_return
 
 
@@ -441,12 +440,11 @@ class PostRequestWithOutput(QThread):
                 #TODO: put inside this [except] some way to kill [self]
 
         else:
-            self.done = False
+            self._done = Event()
             self.already_read = False
             self.my_handler.post_from_main_dui(self.cmd, self)
+            self._done.wait()
 
-            while not self.done:
-                QThread.msleep(10)
 
         logging.info("ended post QThread")
 
@@ -467,7 +465,8 @@ class PostRequestWithOutput(QThread):
                 "do_predict_n_report = " + str(self.do_predict_n_report)
             )
             QThread.msleep(30)
-            self.done = True
+            self._done.set()
+
             self.exit()
             #self.wait()
 

--- a/src/dui2/client/img_view_threads_n_menus.py
+++ b/src/dui2/client/img_view_threads_n_menus.py
@@ -129,7 +129,7 @@ class LoadSliceMaskImage(QThread):
                       "cmd_str" : my_cmd_lst}
 
         else:
-            params_str = str(self.thrs_hld_pars)
+            params_str = json.dumps(self.thrs_hld_pars)
             my_cmd = {
                 'nod_lst': self.nod_num_lst,
                 'path': self.exp_path,

--- a/src/dui2/server/data_n_json.py
+++ b/src/dui2/server/data_n_json.py
@@ -395,9 +395,8 @@ def get_info_data(uni_cmd, cmd_dict, step_list):
                     eq_pos = sub_par.find("=")
                     left_side = sub_par[0:eq_pos]
                     right_side = sub_par[eq_pos + 1:]
-
                     if left_side == "params":
-                        params = eval(right_side)
+                        params = json.loads(right_side)
 
                 str_json = flex_arr_2_json.get_bytes_w_2d_threshold_mask(
                     step_list[lin2go]._lst_expt_out,
@@ -433,7 +432,7 @@ def get_info_data(uni_cmd, cmd_dict, step_list):
                         [x1, y1, x2, y2] = right_side.split(",")
 
                     elif left_side == "params":
-                        params = eval(right_side)
+                        params = json.loads(right_side)
 
                 str_json = flex_arr_2_json.get_bytes_w_2d_threshold_mask_slise(
                     step_list[lin2go]._lst_expt_out,

--- a/src/dui2/server/data_n_json.py
+++ b/src/dui2/server/data_n_json.py
@@ -42,7 +42,7 @@ from dials.command_line.integrate import phil_scope as phil_scope_integrate
 try:
     from dials.command_line.ssx_integrate import phil_scope as ssx_phil_scope_integrate
 
-except:
+except (ImportError, ModuleNotFoundError):
     class dummy_tmp(object):
         pass
 

--- a/src/dui2/shared_modules/img_view_utils.py
+++ b/src/dui2/shared_modules/img_view_utils.py
@@ -23,7 +23,7 @@ copyright (c) CCP4 - DLS
 
 
 import numpy as np
-import time, logging
+import time, logging, json
 
 from dui2.client.init_firts import IniData
 from dui2.client.exec_utils import get_request_shot
@@ -77,7 +77,7 @@ def load_mask_img_json_w_str(
                   "cmd_str" : my_cmd_lst}
 
     else:
-        params_str = str(threshold_params)
+        params_str = json.dumps(threshold_params)
         my_cmd = {
             'nod_lst': nod_num_lst,
             'path': exp_path,


### PR DESCRIPTION
## Summary

Three independent fixes/improvements found while working on DUI2:

### Security: remove `eval()` on network-sourced data
`data_n_json.py`, `img_view_threads_n_menus.py`, and `img_view_utils.py` serialized
parameters passed between client and server using `str()` and reconstructed them with
`eval()`. This is replaced with `json.dumps()` / `json.loads()`. Evaluating arbitrary
strings received over the client-server transport is a code-injection risk.

### Replace busy-wait polling with `threading.Event`
`get_request_shot` and `PostRequestWithOutput` in `exec_utils.py` used
`while not self.done: QThread.msleep(10)` to wait for a response. Swapped for
`threading.Event`, avoiding the polling overhead and the fixed 10ms latency floor.

### Add working-directory picker
`all_local_all_ram.py` gains an `ask4dir` startup option that opens a `QFileDialog`
so the user can choose a working directory at launch, instead of DUI2 always using
whatever directory it happened to be invoked from. As part of this, the log file
(`run_dui2_all_local_all_ram.log`) is now written into the chosen working directory
rather than the invocation directory.

### Minor
Narrowed a bare `except:` around the optional `ssx_integrate` import to
`except (ImportError, ModuleNotFoundError):`.