### PR TITLE
Add startup splash screen and polish message box icons

### DIFF
--- a/src/dui2/all_local_all_ram.py
+++ b/src/dui2/all_local_all_ram.py
@@ -61,7 +61,7 @@ def main():
         msgBox.exec()
 
         dir_2_change = QFileDialog.getExistingDirectory(
-            caption = "Chose working directory"
+            caption = "Choose working directory"
         )
 
         if dir_2_change != '':

--- a/src/dui2/all_local_all_ram.py
+++ b/src/dui2/all_local_all_ram.py
@@ -1,19 +1,10 @@
-import sys, json, os, logging, platform
+import sys, os, platform
 
 from dui2.shared_modules.format_utils import get_feedback_data
 feedback_data_list = get_feedback_data()
 
 from dui2.shared_modules.qt_libs import *
 
-from dui2.client.q_object import MainObject
-from dui2.client.init_firts import IniData
-from dui2.shared_modules import format_utils, all_local_gui_connector
-
-from dui2.server import multi_node
-from dui2.server.init_first import IniData as ServerIniData
-
-
-#logging.basicConfig(filename='run_dui2_all_local_all_ram.log', level=logging.DEBUG)
 
 def main():
     os.environ["QTWEBENGINE_CHROMIUM_FLAGS"] = "--no-sandbox"
@@ -31,6 +22,25 @@ def main():
     else:
         print("neither Linux or Windows")
 
+    app = QApplication(sys.argv)
+    ui_dir_path = os.path.dirname(os.path.abspath(__file__))
+    logo_path = ui_dir_path + os.sep + "client" + os.sep + "resources" \
+              + os.sep + "DIALS_Logo_smaller_centred.png"
+    pixmap = QPixmap(logo_path)
+    splash = QSplashScreen(pixmap, Qt.WindowStaysOnTopHint)
+    splash.showMessage("Starting DUI2...", Qt.AlignBottom | Qt.AlignCenter, Qt.white)
+    splash.show()
+    app.processEvents()  # this forces the splash to actually paint now
+
+    import json, logging
+
+    from dui2.client.q_object import MainObject
+    from dui2.client.init_firts import IniData
+    from dui2.shared_modules import format_utils, all_local_gui_connector
+
+    from dui2.server import multi_node
+    from dui2.server.init_first import IniData as ServerIniData
+
     par_def = (
         ("chdir", None),
         ("ask_for_dir", "false"),
@@ -43,11 +53,9 @@ def main():
         ("cloudrun_id", "xxxx-xxxx-xxxx-xxxx"),
     )
 
-
     init_param = format_utils.get_par(par_def, sys.argv[1:])
     data_init = IniData()
     data_init.set_data(par_def = par_def)
-    app = QApplication(sys.argv)
 
     if init_param["ask_for_dir"] == "false":
         print("Using same dir where Dui2 were invoked from as working dir")
@@ -58,10 +66,12 @@ def main():
         msgBox.setIcon(QMessageBox.Information)
         msgBox.setWindowTitle("Starting DUI")
         msgBox.setText("Please choose a directory to save DUI data in.")
+        splash.finish(msgBox)  # closes splash once main window is shown
+
         msgBox.exec()
 
         dir_2_change = QFileDialog.getExistingDirectory(
-            caption = "Choose working directory"
+            caption = "Chose working directory"
         )
 
         if dir_2_change != '':
@@ -118,14 +128,6 @@ def main():
     tree_ini_path = init_param["limit_path"]
     if tree_ini_path == None:
         tree_ini_path = ""
-        '''
-        #TODO: consider the approach of the next 3 instructions instead
-        logging.info(
-            " using the dir from where the commad 'dui2_server_side' was invoqued"
-        )
-        from pathlib import Path
-        tree_ini_path = str(Path.cwd().parent)
-        '''
 
     try:
         with open("run_data") as json_file:
@@ -152,6 +154,9 @@ def main():
         parent = app, cmd_tree_runner = cmd_runner
     )
     m_obj = MainObject(parent = app, multi_runner = m_gui_obj)
-    sys.exit(app.exec_())
+
+    splash.finish(m_obj.window)  # closes splash once main window is shown
+
+    sys.exit(app.exec())
 
 

--- a/src/dui2/all_local_all_ram.py
+++ b/src/dui2/all_local_all_ram.py
@@ -1,4 +1,4 @@
-import sys, os, platform
+import sys, os, platform, json, logging
 
 from dui2.shared_modules.format_utils import get_feedback_data
 feedback_data_list = get_feedback_data()
@@ -31,8 +31,7 @@ def main():
     splash.showMessage("Starting DUI2...", Qt.AlignBottom | Qt.AlignCenter, Qt.white)
     splash.show()
     app.processEvents()  # this forces the splash to actually paint now
-    app.setWindowIcon(logo_pixmap)
-    import json, logging
+    app.setWindowIcon(QIcon(logo_pixmap))
 
     from dui2.client.q_object import MainObject
     from dui2.client.init_firts import IniData
@@ -66,7 +65,7 @@ def main():
         msgBox.setIcon(QMessageBox.Information)
         msgBox.setWindowTitle("Starting DUI")
         msgBox.setText("Please choose a directory to save DUI data in.")
-        splash.finish(msgBox)  # closes splash once main window is shown
+        splash.finish(msgBox)  # closes splash once this dialog shows
         msgBox.exec()
 
         dir_2_change = QFileDialog.getExistingDirectory(
@@ -153,7 +152,6 @@ def main():
         parent = app, cmd_tree_runner = cmd_runner
     )
     m_obj = MainObject(parent = app, multi_runner = m_gui_obj)
-
     splash.finish(m_obj.window)  # closes splash once main window is shown
 
     sys.exit(app.exec())

--- a/src/dui2/all_local_all_ram.py
+++ b/src/dui2/all_local_all_ram.py
@@ -26,12 +26,12 @@ def main():
     ui_dir_path = os.path.dirname(os.path.abspath(__file__))
     logo_path = ui_dir_path + os.sep + "client" + os.sep + "resources" \
               + os.sep + "DIALS_Logo_smaller_centred.png"
-    pixmap = QPixmap(logo_path)
-    splash = QSplashScreen(pixmap, Qt.WindowStaysOnTopHint)
+    logo_pixmap = QPixmap(logo_path)
+    splash = QSplashScreen(logo_pixmap, Qt.WindowStaysOnTopHint)
     splash.showMessage("Starting DUI2...", Qt.AlignBottom | Qt.AlignCenter, Qt.white)
     splash.show()
     app.processEvents()  # this forces the splash to actually paint now
-
+    app.setWindowIcon(logo_pixmap)
     import json, logging
 
     from dui2.client.q_object import MainObject
@@ -67,11 +67,10 @@ def main():
         msgBox.setWindowTitle("Starting DUI")
         msgBox.setText("Please choose a directory to save DUI data in.")
         splash.finish(msgBox)  # closes splash once main window is shown
-
         msgBox.exec()
 
         dir_2_change = QFileDialog.getExistingDirectory(
-            caption = "Chose working directory"
+            caption = "Choose working directory"
         )
 
         if dir_2_change != '':

--- a/src/dui2/client/q_object.py
+++ b/src/dui2/client/q_object.py
@@ -726,6 +726,7 @@ class MainObject(QObject):
         txt_exit += "Just launch Dui2 again and "
         txt_exit += "it will pickup just where it left off.  "
         msgBox.setText(txt_exit)
+        msgBox.setIcon(QMessageBox.Information)
         msgBox.exec()
         logging.info("exit_triggered(QObject) ... 2")
         self.parent_app.exit()
@@ -761,6 +762,7 @@ class MainObject(QObject):
             full_txt += line_str + "<br>"
         full_txt += "</p>"
         msgBox.setText(full_txt)
+        msgBox.setIcon(QMessageBox.Information)
         msgBox.exec()
         logging.info("Pop feedback info (QObject) ... 2")
 


### PR DESCRIPTION
## Summary
Small UX polish to the local app startup flow — no functional/behavioural changes.

- Add a splash screen (DIALS logo) shown while the heavier `dui2.client`/`dui2.server`
  modules are imported and the GUI initialises, so the app doesn't appear to hang on
  startup. `splash.finish()` is called in both the working-directory-prompt branch and
  at final main-window creation, since either can be the first widget shown depending
  on the `ask_for_dir` path taken.
- Add `QMessageBox.Information` icon to the exit-confirmation and feedback pop-ups in
  `q_object.py` for visual consistency with the other dialogs in the app.
- Fix typo: "Chose working directory" → "Choose working directory".

## Files changed
- `src/dui2/all_local_all_ram.py`
- `src/dui2/client/q_object.py`

## Testing
Tested the fully-local app (`dui2`) on both Linux and Windows, with both
`ask_for_dir=true` and the default `ask_for_dir=false` paths. Splash appears on launch
and closes cleanly in all four combinations.