### PR TITLE
Fix exec()/exec_() PySide compatibility, harden server token checks, add QThread shutdown tracking

### DIFF
--- a/src/dui2/all_local_all_ram.py
+++ b/src/dui2/all_local_all_ram.py
@@ -154,10 +154,4 @@ def main():
     m_obj = MainObject(parent = app, multi_runner = m_gui_obj)
     splash.finish(m_obj.window)  # closes splash once main window is shown
 
-    if hasattr(app, "exec"):
-        sys.exit(app.exec())
-
-    else:
-        sys.exit(app.exec_())
-
-
+    run_qapp(app)

--- a/src/dui2/all_local_all_ram.py
+++ b/src/dui2/all_local_all_ram.py
@@ -154,7 +154,10 @@ def main():
     m_obj = MainObject(parent = app, multi_runner = m_gui_obj)
     splash.finish(m_obj.window)  # closes splash once main window is shown
 
-    print("running ...exec_")
-    sys.exit(app.exec_())
+    if hasattr(app, "exec"):
+        sys.exit(app.exec())
+
+    else:
+        sys.exit(app.exec_())
 
 

--- a/src/dui2/all_local_all_ram.py
+++ b/src/dui2/all_local_all_ram.py
@@ -76,7 +76,7 @@ def main():
             print("Using ", dir_2_change, " as working dir")
 
         else:
-            print("Canceled Operation")
+            print("Canceled Dir selection")
             dir_2_change = os.getcwd()
             #TODO consider interrupting here with the next t line
             #sys.exit(1)

--- a/src/dui2/all_local_all_ram.py
+++ b/src/dui2/all_local_all_ram.py
@@ -154,6 +154,7 @@ def main():
     m_obj = MainObject(parent = app, multi_runner = m_gui_obj)
     splash.finish(m_obj.window)  # closes splash once main window is shown
 
-    sys.exit(app.exec())
+    print("running ...exec_")
+    sys.exit(app.exec_())
 
 

--- a/src/dui2/client/exec_utils.py
+++ b/src/dui2/client/exec_utils.py
@@ -380,7 +380,7 @@ class PostRequestWithOutput(QThread):
         self.my_handler = main_handler
         self.number = None
         self.do_predict_n_report = do_pred_n_rept
-        data_init.register_thread(self)
+        #data_init.register_thread(self)
 
     def run(self):
         if self.my_handler == None:

--- a/src/dui2/client/exec_utils.py
+++ b/src/dui2/client/exec_utils.py
@@ -157,6 +157,7 @@ class GetRequestRealTime(QThread):
         self.token = data_init.get_token()
         self.params = params_in
         self.my_handler = main_handler
+        data_init.register_thread(self)
         logging.info("params_in(GetRequestRealTime) got here" + str(params_in))
 
     def run(self):
@@ -299,6 +300,7 @@ class MtzDataRequest(QThread):
         super(MtzDataRequest, self).__init__()
         self.cmd = cmd
         self.my_handler = main_handler
+        IniData().register_thread(self)
 
     def run(self):
         self.say_goodbye()
@@ -335,6 +337,7 @@ class MtzDataTransfer(QThread):
         super(MtzDataTransfer, self).__init__()
         self.cmd = cmd
         self.my_handler = main_handler
+        IniData().register_thread(self)
 
     def run(self):
         self.say_goodbye()
@@ -377,6 +380,7 @@ class PostRequestWithOutput(QThread):
         self.my_handler = main_handler
         self.number = None
         self.do_predict_n_report = do_pred_n_rept
+        data_init.register_thread(self)
 
     def run(self):
         if self.my_handler == None:
@@ -657,6 +661,7 @@ class HelpRequest(QThread):
     def __init__(self, main_obj):
         super(HelpRequest, self).__init__()
         self.runner_handler = main_obj
+        IniData().register_thread(self)
         self.lst_cmd = [
             "import",
             "generate_mask",

--- a/src/dui2/client/exec_utils.py
+++ b/src/dui2/client/exec_utils.py
@@ -384,6 +384,11 @@ class PostRequestWithOutput(QThread):
                 data_in = dict(self.cmd)
                 data_in["token"] = self.token
                 logging.info("data_in(PostRequestWithOutput)=" + str(data_in))
+
+                print(
+                    "\n data_in(PostRequestWithOutput)=" + str(data_in) + "\n"
+                )
+
                 self.request = requests.post(
                     self.uni_url, stream = True, data = data_in
                 )

--- a/src/dui2/client/exec_utils.py
+++ b/src/dui2/client/exec_utils.py
@@ -384,11 +384,6 @@ class PostRequestWithOutput(QThread):
                 data_in = dict(self.cmd)
                 data_in["token"] = self.token
                 logging.info("data_in(PostRequestWithOutput)=" + str(data_in))
-
-                print(
-                    "\n data_in(PostRequestWithOutput)=" + str(data_in) + "\n"
-                )
-
                 self.request = requests.post(
                     self.uni_url, stream = True, data = data_in
                 )

--- a/src/dui2/client/exec_utils.py
+++ b/src/dui2/client/exec_utils.py
@@ -380,7 +380,7 @@ class PostRequestWithOutput(QThread):
         self.my_handler = main_handler
         self.number = None
         self.do_predict_n_report = do_pred_n_rept
-        #data_init.register_thread(self)
+        data_init.register_thread(self)
 
     def run(self):
         if self.my_handler == None:

--- a/src/dui2/client/file_nav_utils.py
+++ b/src/dui2/client/file_nav_utils.py
@@ -27,6 +27,7 @@ import os, logging, platform
 from dui2.shared_modules.qt_libs import *
 
 from dui2.client.exec_utils import get_req_json_dat
+from dui2.client.init_firts import IniData
 
 def get_number_from_string(dict_in):
     str_in = dict_in['name']
@@ -218,6 +219,7 @@ class ReqDirList(QThread):
         super(ReqDirList, self).__init__()
         self.my_handler = my_handler
         self.show_hidden = show_hidden
+        IniData().register_thread(self)
 
         system = platform.system()
         if system == "Windows":

--- a/src/dui2/client/img_view.py
+++ b/src/dui2/client/img_view.py
@@ -1670,11 +1670,5 @@ def main(par_def = None):
     app = QApplication(sys.argv)
     m_obj = MainImgViewObject(parent = app)
 
-    if hasattr(app, "exec"):
-        sys.exit(app.exec())
-
-    else:
-        sys.exit(app.exec_())
-
-
+    run_qapp(app)
 

--- a/src/dui2/client/img_view.py
+++ b/src/dui2/client/img_view.py
@@ -1669,5 +1669,12 @@ def main(par_def = None):
     uni_url = data_init.get_url()
     app = QApplication(sys.argv)
     m_obj = MainImgViewObject(parent = app)
-    sys.exit(app.exec_())
+
+    if hasattr(app, "exec"):
+        sys.exit(app.exec())
+
+    else:
+        sys.exit(app.exec_())
+
+
 

--- a/src/dui2/client/init_firts.py
+++ b/src/dui2/client/init_firts.py
@@ -114,7 +114,6 @@ class IniData(object):
 
     def register_thread(self, thread):
         global active_threads
-        print("\n adding thread:", thread, "\n")
         active_threads.append(thread)
         thread.finished.connect(lambda: self._forget_thread(thread))
 
@@ -132,9 +131,8 @@ class IniData(object):
                 if thread.isRunning():
                     thread.requestInterruption()
                     thread.quit()
-                    print("just killed:", thread)
                     if not thread.wait(timeout_ms):
-                        print(
+                        logging.info(
                             "Thread: " + str(thread) +
                             " did not exit gracefully, terminating"
                         )
@@ -143,7 +141,7 @@ class IniData(object):
 
             except RuntimeError:
                 # underlying C++ QThread object already deleted
-                print("Thread already deleted (IniData sweep)")
+                logging.info("Thread already deleted (IniData sweep)")
 
         active_threads = []
 

--- a/src/dui2/client/init_firts.py
+++ b/src/dui2/client/init_firts.py
@@ -114,6 +114,7 @@ class IniData(object):
 
     def register_thread(self, thread):
         global active_threads
+        print("\n adding thread:", thread, "\n")
         active_threads.append(thread)
         thread.finished.connect(lambda: self._forget_thread(thread))
 

--- a/src/dui2/client/init_firts.py
+++ b/src/dui2/client/init_firts.py
@@ -114,7 +114,6 @@ class IniData(object):
 
     def register_thread(self, thread):
         global active_threads
-        print("\n adding thread:", thread, "\n")
         active_threads.append(thread)
         thread.finished.connect(lambda: self._forget_thread(thread))
 

--- a/src/dui2/client/init_firts.py
+++ b/src/dui2/client/init_firts.py
@@ -83,6 +83,9 @@ class IniData(object):
 
         logging.info("\n win_exe =" + str(win_exe))
 
+        global active_threads
+        active_threads = []
+
     def set_tmp_dir(self, dir_path_in):
         global tmp_dir
         tmp_dir = dir_path_in
@@ -108,6 +111,41 @@ class IniData(object):
 
     def get_win_exe(self):
         return win_exe
+
+    def register_thread(self, thread):
+        global active_threads
+        print("\n adding thread:", thread, "\n")
+        active_threads.append(thread)
+        thread.finished.connect(lambda: self._forget_thread(thread))
+
+    def _forget_thread(self, thread):
+        try:
+            active_threads.remove(thread)
+
+        except ValueError:
+            pass
+
+    def quit_kill_all_threads(self, timeout_ms = 1200):
+        global active_threads
+        for thread in list(active_threads):
+            try:
+                if thread.isRunning():
+                    thread.requestInterruption()
+                    thread.quit()
+                    print("just killed:", thread)
+                    if not thread.wait(timeout_ms):
+                        print(
+                            "Thread: " + str(thread) +
+                            " did not exit gracefully, terminating"
+                        )
+                        thread.terminate()
+                        thread.wait()
+
+            except RuntimeError:
+                # underlying C++ QThread object already deleted
+                print("Thread already deleted (IniData sweep)")
+
+        active_threads = []
 
 
 if __name__ == "__main__":

--- a/src/dui2/client/q_object.py
+++ b/src/dui2/client/q_object.py
@@ -740,6 +740,7 @@ class MainObject(QObject):
         )
         resp = lst_req.result_out()
         self.do_image_view.quit_kill_all()
+        IniData().quit_kill_all_threads()
         print(" end Quit ...")
         feedback_data_list = get_feedback_data()
 

--- a/src/dui2/client/q_object.py
+++ b/src/dui2/client/q_object.py
@@ -739,6 +739,9 @@ class MainObject(QObject):
             params_in = cmd, main_handler = self.runner_handler
         )
         resp = lst_req.result_out()
+
+        self.quit_kill_all_threads()
+
         self.do_image_view.quit_kill_all()
         IniData().quit_kill_all_threads()
         print(" end Quit ...")
@@ -1720,4 +1723,25 @@ class MainObject(QObject):
         else:
             self.refresh_output()
 
+
+    def quit_kill_all_threads(self, timeout_ms = 1200):
+        for thread in list(self.thrd_lst):
+            try:
+                if thread.isRunning():
+                    thread.requestInterruption()
+                    thread.quit()
+                    print("just killed:", thread)
+                    if not thread.wait(timeout_ms):
+                        print(
+                            "Thread: " + str(thread) +
+                            " did not exit gracefully, terminating"
+                        )
+                        thread.terminate()
+                        thread.wait()
+
+            except RuntimeError:
+                # underlying C++ QThread object already deleted
+                print("Thread already deleted (IniData sweep)")
+
+        self.thrd_lst = []
 

--- a/src/dui2/client/q_object.py
+++ b/src/dui2/client/q_object.py
@@ -739,9 +739,6 @@ class MainObject(QObject):
             params_in = cmd, main_handler = self.runner_handler
         )
         resp = lst_req.result_out()
-
-        self.quit_kill_all_threads()
-
         self.do_image_view.quit_kill_all()
         IniData().quit_kill_all_threads()
         print(" end Quit ...")
@@ -1723,25 +1720,4 @@ class MainObject(QObject):
         else:
             self.refresh_output()
 
-
-    def quit_kill_all_threads(self, timeout_ms = 1200):
-        for thread in list(self.thrd_lst):
-            try:
-                if thread.isRunning():
-                    thread.requestInterruption()
-                    thread.quit()
-                    print("just killed:", thread)
-                    if not thread.wait(timeout_ms):
-                        print(
-                            "Thread: " + str(thread) +
-                            " did not exit gracefully, terminating"
-                        )
-                        thread.terminate()
-                        thread.wait()
-
-            except RuntimeError:
-                # underlying C++ QThread object already deleted
-                print("Thread already deleted (IniData sweep)")
-
-        self.thrd_lst = []
 

--- a/src/dui2/client/reindex_table.py
+++ b/src/dui2/client/reindex_table.py
@@ -25,7 +25,14 @@ import json
 import sys
 import os, logging
 
-from dui2.shared_modules.qt_libs import *
+try:
+    from dui2.shared_modules.qt_libs import *
+
+except ModuleNotFoundError:
+    # in case of non ccp4-python available
+    from PySide6.QtCore import *
+    from PySide6.QtWidgets import *
+    from PySide6.QtGui import *
 
 def choice_if_decimal(num_in):
     str_f = "{:6.2f}".format(num_in)
@@ -299,11 +306,11 @@ class MainWindow(QMainWindow):
     def __init__(self, parent=None):
         super(MainWindow, self).__init__(parent)
 
-        #full_json_path = "/home/lui-temp/xrd_data/tst_area/run4/bravais_summary.json"
-        #full_log_path = "/home/lui-temp/xrd_data/tst_area/run4/out.log"
+        full_json_path = "/tmp/tst4img/bravais_summary.json"
+        full_log_path = "/tmp/tst4img/dials.refine_bravais_settings.log"
 
-        full_json_path = "/tmp/run6/bravais_summary.json"
-        full_log_path = "/tmp/run6/out.log"
+        '''full_json_path = "/tmp/run6/bravais_summary.json"
+        full_log_path = "/tmp/run6/out.log"'''
 
         with open(full_json_path) as json_file:
             json_data = json.load(json_file)
@@ -331,8 +338,12 @@ if __name__ == "__main__":
     app = QApplication(sys.argv)
     myWidget = MainWindow()
     myWidget.show()
-    app.exec_()
 
+    if hasattr(app, "exec"):
+        app.exec()
+
+    else:
+        app.exec_()
 
 
 

--- a/src/dui2/client/reindex_table.py
+++ b/src/dui2/client/reindex_table.py
@@ -22,7 +22,6 @@ copyright (c) CCP4 - DLS
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 import json
-import sys
 import os, logging
 
 try:
@@ -335,14 +334,29 @@ class MainWindow(QMainWindow):
 
 
 if __name__ == "__main__":
+    import sys, platform
+
+    if platform.system() == "Windows":
+        print("running on Windows")
+
+    elif platform.system() == "Linux":
+        print("running on Linux")
+        os.environ["QT_QPA_PLATFORM"] = "xcb"
+        os.environ["WAYLAND_DISPLAY"] = ""
+
+    else:
+        print("nether Linux or Windows")
+
     app = QApplication(sys.argv)
     myWidget = MainWindow()
     myWidget.show()
 
     if hasattr(app, "exec"):
+        print("\n using exec \n")
         app.exec()
 
     else:
+        print("\n using exec_ \n")
         app.exec_()
 
 

--- a/src/dui2/client/run_client.py
+++ b/src/dui2/client/run_client.py
@@ -75,5 +75,11 @@ def main(par_def = None):
 
     app = QApplication(sys.argv)
     m_obj = MainObject(parent = app)
-    sys.exit(app.exec_())
+
+    if hasattr(app, "exec"):
+        sys.exit(app.exec())
+
+    else:
+        sys.exit(app.exec_())
+
 

--- a/src/dui2/client/run_client.py
+++ b/src/dui2/client/run_client.py
@@ -76,10 +76,5 @@ def main(par_def = None):
     app = QApplication(sys.argv)
     m_obj = MainObject(parent = app)
 
-    if hasattr(app, "exec"):
-        sys.exit(app.exec())
-
-    else:
-        sys.exit(app.exec_())
-
+    run_qapp(app)
 

--- a/src/dui2/client/tests/test_connect_get_history.py
+++ b/src/dui2/client/tests/test_connect_get_history.py
@@ -36,6 +36,13 @@ if __name__ == "__main__":
     }
     #'''
 
+    misspell_token = '''
+    full_cmd = {
+        "nod_lst":"", "cmd_str":["history"],
+        'tock': 'dummy_4_now'
+    }
+    #'''
+
     no_token_error = '''
     full_cmd = {
         "nod_lst":"", "cmd_str":["history"]

--- a/src/dui2/client/tests/test_connect_get_history.py
+++ b/src/dui2/client/tests/test_connect_get_history.py
@@ -29,10 +29,28 @@ uni_url = 'http://127.0.0.1:45678/'
 #uni_url = 'http://supercomputo.cimav.edu.mx:45678/'
 
 if __name__ == "__main__":
+    #correct = '''
     full_cmd = {
         "nod_lst":"", "cmd_str":["history"],
         'token': 'dummy_4_now'
     }
+    #'''
+
+    no_token_error = '''
+    full_cmd = {
+        "nod_lst":"", "cmd_str":["history"]
+    }
+    #'''
+
+    wrong_token_error = '''
+    full_cmd = {
+        "nod_lst":"", "cmd_str":["history"],
+        'token': 'dummy_4_nowww'
+    }
+    #'''
+
+
+
     req_get = requests.get(uni_url, stream = True, params = full_cmd)
     print("\n url =\n", req_get.url, "\n")
 

--- a/src/dui2/client/tests/test_connect_get_history.py
+++ b/src/dui2/client/tests/test_connect_get_history.py
@@ -29,6 +29,7 @@ uni_url = 'http://127.0.0.1:45678/'
 #uni_url = 'http://supercomputo.cimav.edu.mx:45678/'
 
 if __name__ == "__main__":
+
     #correct = '''
     full_cmd = {
         "nod_lst":"", "cmd_str":["history"],
@@ -55,8 +56,6 @@ if __name__ == "__main__":
         'token': 'dummy_4_nowww'
     }
     #'''
-
-
 
     req_get = requests.get(uni_url, stream = True, params = full_cmd)
     print("\n url =\n", req_get.url, "\n")

--- a/src/dui2/client/tests/test_connect_post.py
+++ b/src/dui2/client/tests/test_connect_post.py
@@ -31,24 +31,27 @@ uni_url = 'http://127.0.0.1:45678/'
 
 if __name__ == "__main__":
 
-        new_tst = '''
-        full_cmd = {'nod_lst': [48], 'cmd_lst': ['split_node']}
+        #correct = '''
         full_cmd = {
-            'nod_lst': [0],
-            'cmd_lst': [
-                'dials.import input.template="/home/luiso/dif_dat/C2sum_5/C2sum_5_####.cbf.gz"'
-            ]
+            'nod_lst': [3], 'cmd_lst': ['dials.refine'], 'token': 'dummy_4_now'
         }
-        '''
+        #'''
 
+        wrong_token = '''
         full_cmd = {
-            'nod_lst': [0],
-            'cmd_lst': [
-                'dials.import /home/lui/dif_dat/x4w_g1/X4_wide_M1S4_2_*.cbf'
-            ]
+            'nod_lst': [3], 'cmd_lst': ['dials.refine'], 'token': 'dummy_never'
+        }
+        #'''
+
+        misspell_key_token = '''
+        full_cmd = {
+            'nod_lst': [3], 'cmd_lst': ['dials.refine'], 'tock': 'dummy_4_now'
         }
 
+        #'''
 
+
+        #full_cmd = {'nod_lst': [4], 'cmd_lst': ['run_predict_n_report'], 'token': 'dummy_4_now'}
 
 
         req_post = requests.post(uni_url, stream = True, data = full_cmd)

--- a/src/dui2/client/tests/test_connect_post.py
+++ b/src/dui2/client/tests/test_connect_post.py
@@ -50,9 +50,7 @@ if __name__ == "__main__":
 
         #'''
 
-
         #full_cmd = {'nod_lst': [4], 'cmd_lst': ['run_predict_n_report'], 'token': 'dummy_4_now'}
-
 
         req_post = requests.post(uni_url, stream = True, data = full_cmd)
         while True:

--- a/src/dui2/multi_user/client_gui.py
+++ b/src/dui2/multi_user/client_gui.py
@@ -158,5 +158,9 @@ def main():
         parent = None, domain = domain, port_num = port_num, url_opt = url_opt
     )
 
-    sys.exit(app.exec_())
+    if hasattr(app, "exec"):
+        sys.exit(app.exec())
+
+    else:
+        sys.exit(app.exec_())
 

--- a/src/dui2/server/data_n_json.py
+++ b/src/dui2/server/data_n_json.py
@@ -250,7 +250,7 @@ def get_info_data(uni_cmd, cmd_dict, step_list):
                 new_line = None
                 while cloudrun_proc.poll() is None or new_line != '':
                     new_line = cloudrun_proc.stdout.readline()
-                    print("cloudrun new_line =", new_line[:-1])
+                    logging.info("cloudrun new_line =" + str(new_line[:-1]))
                     lst_line.append(new_line)
 
                 for out_line in lst_line:

--- a/src/dui2/server/multi_node.py
+++ b/src/dui2/server/multi_node.py
@@ -816,7 +816,7 @@ class Runner(object):
             return_list = [self._dir_path]
 
         elif unalias_cmd_lst == ["history"]:
-            print("Running history command")
+            logging.info("Running history command")
             if self.win_exe:
                 make_dir_str = "md "
 

--- a/src/dui2/server/run_server.py
+++ b/src/dui2/server/run_server.py
@@ -64,7 +64,7 @@ def main(par_def = None, connection_out = None):
                     )
 
                 spit_out(
-                    str_out = 'no command in request (Key err catch ) ',
+                    str_out = 'rejected: invalid token',
                     req_obj = self, out_type = 'utf-8'
                 )
                 spit_out(
@@ -157,7 +157,7 @@ def main(par_def = None, connection_out = None):
                 except AttributeError:
                     logging.info("Attribute Err catch, not supposed send header info #4")
 
-                spit_out(str_out = 'no command in request (KeyError) ', req_obj = self, out_type = 'utf-8')
+                spit_out(str_out = 'rejected: invalid token', req_obj = self, out_type = 'utf-8')
                 spit_out(str_out = '/*EOF*/', req_obj = self, out_type = 'utf-8')
                 return
 
@@ -169,7 +169,6 @@ def main(par_def = None, connection_out = None):
                 logging.info("no node number provided")
 
             cmd_dict = {"nod_lst":nod_lst, "lst_wt_cmd":lst_wt_cmd}
-            # rest of the method (run_get_data etc.) unchanged
 
             try:
                 lst_out = cmd_tree_runner.run_get_data(cmd_dict)

--- a/src/dui2/server/run_server.py
+++ b/src/dui2/server/run_server.py
@@ -94,7 +94,6 @@ def main(par_def = None, connection_out = None):
                     if "dials" in single_str:
                         found_dials_command = True
 
-
             if found_dials_command:
                 try:
                     cmd_tree_runner.run_dials_command(cmd_dict, self)
@@ -238,7 +237,7 @@ def main(par_def = None, connection_out = None):
                     "ConnectionReset err catch  ** while sending EOF or JSON"
                 )
 
-            logging.info("\n do_GET ... done ")
+            logging.info("do_GET ... done ")
 
         def log_message(self, format, *args):
             if run_local:

--- a/src/dui2/server/run_server.py
+++ b/src/dui2/server/run_server.py
@@ -45,7 +45,7 @@ def main(par_def = None, connection_out = None):
             url_dict = parse_qs(body_str)
 
             if "cmd_lst" not in url_dict or "token" not in url_dict:
-                print("\n request (POST) with wrong token or wrong command \n")
+                logging.info("\n request (POST) with wrong token or wrong command \n")
                 return
 
             tmp_cmd2lst = url_dict["cmd_lst"]
@@ -57,7 +57,7 @@ def main(par_def = None, connection_out = None):
                     self.end_headers()
 
                 except AttributeError:
-                    print(
+                    logging.info(
                         "Attribute Err catch," +
                         " not supposed send header info"
                     )
@@ -82,7 +82,7 @@ def main(par_def = None, connection_out = None):
                     nod_lst.append(int(inner_str))
 
             except KeyError:
-                print("no node number provided")
+                logging.info("no node number provided")
 
             cmd_dict = {"nod_lst":nod_lst,
                         "cmd_lst":cmd_lst}
@@ -137,51 +137,39 @@ def main(par_def = None, connection_out = None):
                 self.send_response(200)
 
             except AttributeError:
-                print(
-                    "Attribute Err catch, not supposed send header info #3"
-                )
+                logging.info("Attribute Err catch, not supposed send header info #3")
 
             url_path = self.path
             url_dict = parse_qs(urlparse(url_path).query)
-            try:
-                lst_wt_cmd =  url_dict["cmd_str"]
-                token_from_url = url_dict["token"][0]
-                if not run_local and token_from_url != token_from_cli:
-                    print("\n request (GET) with wrong token \n")
-                    return
 
-            except KeyError:
-                print(
-                    "no command or no token in GET request (Key Err Catch)"
-                )
+            if "cmd_str" not in url_dict or "token" not in url_dict:
+                logging.info("\n request (GET) with wrong token or wrong command \n")
+                return
+
+            lst_wt_cmd = url_dict["cmd_str"]
+            token_from_url = url_dict["token"][0]
+            if not run_local and token_from_url != token_from_cli:
                 try:
                     self.send_header('Content-type', 'text/plain')
                     self.end_headers()
 
                 except AttributeError:
-                    print(
-                        "Attribute Err catch, not supposed send header info #4"
-                    )
+                    logging.info("Attribute Err catch, not supposed send header info #4")
 
-                spit_out(
-                    str_out = 'no command in request (KeyError) ',
-                    req_obj = self, out_type = 'utf-8'
-                )
-                spit_out(
-                    str_out = '/*EOF*/', req_obj = self, out_type = 'utf-8'
-                )
+                spit_out(str_out = 'no command in request (KeyError) ', req_obj = self, out_type = 'utf-8')
+                spit_out(str_out = '/*EOF*/', req_obj = self, out_type = 'utf-8')
                 return
 
             nod_lst = []
             try:
                 for inner_str in url_dict["nod_lst"]:
                     nod_lst.append(int(inner_str))
-
             except KeyError:
                 logging.info("no node number provided")
 
-            cmd_dict = {"nod_lst":nod_lst,
-                        "lst_wt_cmd":lst_wt_cmd}
+            cmd_dict = {"nod_lst":nod_lst, "lst_wt_cmd":lst_wt_cmd}
+            # rest of the method (run_get_data etc.) unchanged
+
             try:
                 lst_out = cmd_tree_runner.run_get_data(cmd_dict)
 
@@ -258,7 +246,7 @@ def main(par_def = None, connection_out = None):
                 log_full_str = self.address_string() + " => " + \
                                self.log_date_time_string() + "  " + str(args)
 
-                print(log_full_str)
+                logging.info(log_full_str)
                 return
 
     ################################################ PROPER MAIN

--- a/src/dui2/server/run_server.py
+++ b/src/dui2/server/run_server.py
@@ -44,23 +44,20 @@ def main(par_def = None, connection_out = None):
             body_str = str(post_body.decode('utf-8'))
             url_dict = parse_qs(body_str)
 
-            try:
-                tmp_cmd2lst = url_dict["cmd_lst"]
-                token_from_url = url_dict["token"][0]
-                if not run_local and token_from_url != token_from_cli:
-                    print("\n request (POST) with wrong token \n")
-                    return
+            if "cmd_lst" not in url_dict or "token" not in url_dict:
+                print("\n request (POST) with wrong token or wrong command \n")
+                return
 
-            except KeyError:
-                logging.info(
-                    "no command or no token in POST request (Key Err Catch)"
-                )
+            tmp_cmd2lst = url_dict["cmd_lst"]
+            token_from_url = url_dict["token"][0]
+            if not run_local and token_from_url != token_from_cli:
+
                 try:
                     self.send_header('Content-type', 'text/plain')
                     self.end_headers()
 
                 except AttributeError:
-                    logging.info(
+                    print(
                         "Attribute Err catch," +
                         " not supposed send header info"
                     )
@@ -85,7 +82,7 @@ def main(par_def = None, connection_out = None):
                     nod_lst.append(int(inner_str))
 
             except KeyError:
-                logging.info("no node number provided")
+                print("no node number provided")
 
             cmd_dict = {"nod_lst":nod_lst,
                         "cmd_lst":cmd_lst}
@@ -136,12 +133,11 @@ def main(par_def = None, connection_out = None):
                     )
 
         def do_GET(self):
-
             try:
                 self.send_response(200)
 
             except AttributeError:
-                logging.info(
+                print(
                     "Attribute Err catch, not supposed send header info #3"
                 )
 
@@ -155,7 +151,7 @@ def main(par_def = None, connection_out = None):
                     return
 
             except KeyError:
-                logging.info(
+                print(
                     "no command or no token in GET request (Key Err Catch)"
                 )
                 try:
@@ -163,7 +159,7 @@ def main(par_def = None, connection_out = None):
                     self.end_headers()
 
                 except AttributeError:
-                    logging.info(
+                    print(
                         "Attribute Err catch, not supposed send header info #4"
                     )
 

--- a/src/dui2/server/run_server.py
+++ b/src/dui2/server/run_server.py
@@ -45,12 +45,13 @@ def main(par_def = None, connection_out = None):
             url_dict = parse_qs(body_str)
 
             if "cmd_lst" not in url_dict or "token" not in url_dict:
-                logging.info("\n request (POST) with wrong token or wrong command \n")
+                logging.info("request (POST) without token or command")
                 return
 
             tmp_cmd2lst = url_dict["cmd_lst"]
             token_from_url = url_dict["token"][0]
             if not run_local and token_from_url != token_from_cli:
+                logging.info("request (POST) with wrong token")
 
                 try:
                     self.send_header('Content-type', 'text/plain')

--- a/src/dui2/server/run_server.py
+++ b/src/dui2/server/run_server.py
@@ -143,12 +143,13 @@ def main(par_def = None, connection_out = None):
             url_dict = parse_qs(urlparse(url_path).query)
 
             if "cmd_str" not in url_dict or "token" not in url_dict:
-                logging.info("\n request (GET) with wrong token or wrong command \n")
+                logging.info("request (GET) without token or command")
                 return
 
             lst_wt_cmd = url_dict["cmd_str"]
             token_from_url = url_dict["token"][0]
             if not run_local and token_from_url != token_from_cli:
+                logging.info("request (GET) with wrong token")
                 try:
                     self.send_header('Content-type', 'text/plain')
                     self.end_headers()

--- a/src/dui2/shared_modules/all_local_gui_connector.py
+++ b/src/dui2/shared_modules/all_local_gui_connector.py
@@ -3,6 +3,7 @@ import logging
 from dui2.shared_modules.qt_libs import *
 
 from dui2.shared_modules import all_local_server, format_utils
+from dui2.client.init_firts import IniData
 
 class ConnectGetThread(QThread):
     def __init__(self, handler, cmd_in, obj_out):
@@ -10,6 +11,7 @@ class ConnectGetThread(QThread):
         self.my_handler = handler
         self.my_cmd = cmd_in
         self.my_caller = obj_out
+        IniData().register_thread(self)
 
     def run(self):
         self.my_handler.fake_get(
@@ -30,6 +32,7 @@ class ConnectPostThread(QThread):
         self.my_cmd = cmd_in
         self.my_caller = obj_out
         logging.info("my_cmd(ConnectPostThread)=" + str(self.my_cmd))
+        IniData().register_thread(self)
 
     def run(self):
         self.my_handler.fake_post(

--- a/src/dui2/shared_modules/all_local_gui_connector.py
+++ b/src/dui2/shared_modules/all_local_gui_connector.py
@@ -3,7 +3,6 @@ import logging
 from dui2.shared_modules.qt_libs import *
 
 from dui2.shared_modules import all_local_server, format_utils
-from dui2.client.init_firts import IniData
 
 class ConnectGetThread(QThread):
     def __init__(self, handler, cmd_in, obj_out):
@@ -11,7 +10,6 @@ class ConnectGetThread(QThread):
         self.my_handler = handler
         self.my_cmd = cmd_in
         self.my_caller = obj_out
-        IniData().register_thread(self)
 
     def run(self):
         self.my_handler.fake_get(
@@ -32,7 +30,6 @@ class ConnectPostThread(QThread):
         self.my_cmd = cmd_in
         self.my_caller = obj_out
         logging.info("my_cmd(ConnectPostThread)=" + str(self.my_cmd))
-        IniData().register_thread(self)
 
     def run(self):
         self.my_handler.fake_post(

--- a/src/dui2/shared_modules/qt_libs.py
+++ b/src/dui2/shared_modules/qt_libs.py
@@ -24,6 +24,14 @@ copyright (c) CCP4 - DLS
 import os
 import sys
 
+def run_qapp(app):
+    if hasattr(app, "exec"):
+        sys.exit(app.exec())
+
+    else:
+        sys.exit(app.exec_())
+
+
 def is_webengine_functional(pyside_ver):
     # 1. Check if module is even importable
     try:


### PR DESCRIPTION
Fix exec()/exec_() PySide compatibility, harden server token checks, add QThread shutdown tracking

- Add run_qapp() helper (qt_libs.py) for PySide2/PySide6 exec() compatibility,
  used in all_local_all_ram.py, img_view.py, run_client.py
- Replace try/except KeyError with explicit key checks in do_POST/do_GET
  (run_server.py); fix misleading "invalid token" response message
- Convert remaining print() calls to logging in run_server.py,
  data_n_json.py, multi_node.py
- Add IniData.register_thread()/quit_kill_all_threads() for graceful
  QThread shutdown on app quit (init_firts.py, q_object.py)
- Allow reindex_table.py to run standalone without ccp4-python; set
  QT_QPA_PLATFORM/WAYLAND_DISPLAY automatically on Linux